### PR TITLE
feat: replace HTTP polling with WebSocket Comms API + readOnlyHint annotations

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "pino-http": "^11.0.0",
     "pino-pretty": "^13.1.1",
     "uuid": "^13.0.0",
+    "ws": "^8.20.0",
     "zod": "^4.1.13"
   },
   "devDependencies": {

--- a/src/server/express-app.ts
+++ b/src/server/express-app.ts
@@ -45,6 +45,7 @@ export class ExpressApp {
   private oauthServer: OAuthServer;
   private sessionManager: SessionManager;
   private config: ExpressAppConfig;
+  private monitoringInterval: ReturnType<typeof setInterval> | null = null;
 
   constructor(mcpServer: McpNodeRedServer, config: Partial<ExpressAppConfig> = {}) {
     this.mcpServer = mcpServer;
@@ -236,7 +237,7 @@ export class ExpressApp {
    * Setup API routes
    */
   private setupRoutes(): void {
-    // ── OAuth 2.0 routes (must be before auth middleware) ─────────────────────
+    // ── OAuth 2.0 routes (must be before auth middleware) ─────────────────
     const baseUrl = process.env.PUBLIC_URL || `http://${this.config.host}:${this.config.port}`;
     this.app.use(this.oauthServer.createRouter(baseUrl));
 
@@ -677,7 +678,7 @@ export class ExpressApp {
           // Send connection status
           res.write(`event: connection-status\n`);
           res.write(
-            `data: {"status": "connected", "timestamp": "${new Date().toISOString()}"}\n\n`
+            `data: {"status": "connected", "timestamp": "${new Date().toISOString}"}\n\n`
           );
 
           // Keep connection alive with periodic heartbeat
@@ -1402,12 +1403,9 @@ export class ExpressApp {
    * Start system monitoring (send periodic updates via SSE)
    */
   startSystemMonitoring(intervalMs = 30000): void {
-    // Start system info updates
-    setInterval(() => {
+    this.monitoringInterval = setInterval(() => {
       this.sendSystemInfo();
     }, intervalMs);
-
-    // Start Node-RED event monitoring
     this.eventListener.startEventMonitoring();
   }
 
@@ -1415,6 +1413,10 @@ export class ExpressApp {
    * Stop system monitoring
    */
   stopSystemMonitoring(): void {
+    if (this.monitoringInterval) {
+      clearInterval(this.monitoringInterval);
+      this.monitoringInterval = null;
+    }
     this.eventListener.stopEventMonitoring();
   }
 

--- a/src/server/express-app.ts
+++ b/src/server/express-app.ts
@@ -236,7 +236,7 @@ export class ExpressApp {
    * Setup API routes
    */
   private setupRoutes(): void {
-    // ── OAuth 2.0 routes (must be before auth middleware) ─────────────────
+    // ── OAuth 2.0 routes (must be before auth middleware) ─────────────────────
     const baseUrl = process.env.PUBLIC_URL || `http://${this.config.host}:${this.config.port}`;
     this.app.use(this.oauthServer.createRouter(baseUrl));
 
@@ -1408,7 +1408,7 @@ export class ExpressApp {
     }, intervalMs);
 
     // Start Node-RED event monitoring
-    this.eventListener.startEventMonitoring(5000); // Check every 5 seconds
+    this.eventListener.startEventMonitoring();
   }
 
   /**

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -125,6 +125,7 @@ export class McpNodeRedServer {
         name: 'get_flows',
         description:
           'Get Node-RED flows with flexible filtering (summary info by default, use includeDetails for full data)',
+        annotations: { readOnlyHint: true },
         inputSchema: {
           type: 'object',
           properties: {
@@ -148,6 +149,7 @@ export class McpNodeRedServer {
       {
         name: 'get_flow',
         description: 'Get specific Node-RED flow by ID',
+        annotations: { readOnlyHint: true },
         inputSchema: {
           type: 'object',
           properties: {
@@ -159,6 +161,7 @@ export class McpNodeRedServer {
       {
         name: 'create_flow',
         description: 'Create a new Node-RED flow',
+        annotations: { readOnlyHint: false },
         inputSchema: {
           type: 'object',
           properties: {
@@ -178,6 +181,7 @@ export class McpNodeRedServer {
       {
         name: 'update_flow',
         description: 'Update an existing Node-RED flow',
+        annotations: { readOnlyHint: false },
         inputSchema: {
           type: 'object',
           properties: {
@@ -190,6 +194,7 @@ export class McpNodeRedServer {
       {
         name: 'enable_flow',
         description: 'Enable a specific Node-RED flow',
+        annotations: { readOnlyHint: false },
         inputSchema: {
           type: 'object',
           properties: {
@@ -201,6 +206,7 @@ export class McpNodeRedServer {
       {
         name: 'disable_flow',
         description: 'Disable a specific Node-RED flow',
+        annotations: { readOnlyHint: false },
         inputSchema: {
           type: 'object',
           properties: {
@@ -212,6 +218,7 @@ export class McpNodeRedServer {
       {
         name: 'search_modules',
         description: 'Search for Node-RED palette modules online via npm registry',
+        annotations: { readOnlyHint: true },
         inputSchema: {
           type: 'object',
           properties: {
@@ -239,6 +246,7 @@ export class McpNodeRedServer {
       {
         name: 'install_module',
         description: 'Install a Node-RED palette module via Node-RED palette management API',
+        annotations: { readOnlyHint: false },
         inputSchema: {
           type: 'object',
           properties: {
@@ -257,6 +265,7 @@ export class McpNodeRedServer {
       {
         name: 'get_installed_modules',
         description: 'Get list of currently installed Node-RED palette modules',
+        annotations: { readOnlyHint: true },
         inputSchema: {
           type: 'object',
           properties: {},

--- a/src/services/nodered-event-listener.test.ts
+++ b/src/services/nodered-event-listener.test.ts
@@ -1,6 +1,6 @@
 /**
  * NodeRedEventListener tests
- * Tests for the Node-RED event listener service
+ * Tests for the Node-RED event listener service (WebSocket-based)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -9,98 +9,78 @@ import { SSEHandler } from '../server/sse-handler.js';
 
 import { NodeRedAPIClient } from './nodered-api.js';
 import { NodeRedEventListener } from './nodered-event-listener.js';
+import { NodeRedWsClient } from './nodered-ws-client.js';
 
-// Mock SSEHandler
 vi.mock('../server/sse-handler.js', () => ({
-  SSEHandler: vi.fn().mockImplementation(() => ({
-    broadcast: vi.fn(),
-  })),
+  SSEHandler: vi.fn().mockImplementation(() => ({ broadcast: vi.fn() })),
 }));
 
-// Mock NodeRedAPIClient
 vi.mock('./nodered-api.js', () => ({
-  NodeRedAPIClient: vi.fn().mockImplementation(() => ({
-    healthCheck: vi.fn().mockResolvedValue({ healthy: true }),
-    getFlows: vi.fn().mockResolvedValue([
-      { id: 'flow-1', type: 'tab', label: 'Test Flow 1' },
-      { id: 'flow-2', type: 'tab', label: 'Test Flow 2' },
-    ]),
-  })),
+  NodeRedAPIClient: vi.fn().mockImplementation(() => ({})),
 }));
+
+vi.mock('./nodered-ws-client.js', () => ({
+  NodeRedWsClient: vi.fn(),
+}));
+
+function makeMockWsClient() {
+  return {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    isConnected: vi.fn().mockReturnValue(false),
+  };
+}
 
 describe('NodeRedEventListener', () => {
   let eventListener: NodeRedEventListener;
   let mockSSEHandler: { broadcast: ReturnType<typeof vi.fn> };
-  let mockNodeRedClient: {
-    healthCheck: ReturnType<typeof vi.fn>;
-    getFlows: ReturnType<typeof vi.fn>;
-  };
+  let mockNodeRedClient: object;
+  let mockWsClient: ReturnType<typeof makeMockWsClient>;
 
   beforeEach(() => {
-    vi.useFakeTimers();
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    mockSSEHandler = {
-      broadcast: vi.fn(),
-    };
-
-    mockNodeRedClient = {
-      healthCheck: vi.fn().mockResolvedValue({ healthy: true }),
-      getFlows: vi.fn().mockResolvedValue([
-        { id: 'flow-1', type: 'tab', label: 'Test Flow 1' },
-        { id: 'flow-2', type: 'tab', label: 'Test Flow 2' },
-      ]),
-    };
+    mockSSEHandler = { broadcast: vi.fn() };
+    mockNodeRedClient = {};
+    mockWsClient = makeMockWsClient();
 
     eventListener = new NodeRedEventListener(
       mockSSEHandler as unknown as SSEHandler,
-      mockNodeRedClient as unknown as NodeRedAPIClient
+      mockNodeRedClient as unknown as NodeRedAPIClient,
+      mockWsClient as unknown as NodeRedWsClient
     );
   });
 
   afterEach(() => {
     eventListener.stopEventMonitoring();
-    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
   describe('constructor', () => {
-    it('should create instance with SSEHandler and NodeRedAPIClient', () => {
-      expect(eventListener).toBeDefined();
+    it('should create instance', () => {
       expect(eventListener).toBeInstanceOf(NodeRedEventListener);
     });
 
-    it('should initialize with monitoring stopped', () => {
-      const status = eventListener.getStatus();
-      expect(status.isMonitoring).toBe(false);
+    it('should initialise with monitoring stopped', () => {
+      expect(eventListener.getStatus().isMonitoring).toBe(false);
     });
 
-    it('should initialize lastEventTimestamp', () => {
-      const status = eventListener.getStatus();
-      expect(status.lastEventTimestamp).toBeDefined();
-      expect(typeof status.lastEventTimestamp).toBe('number');
+    it('should initialise lastEventTimestamp', () => {
+      const { lastEventTimestamp } = eventListener.getStatus();
+      expect(typeof lastEventTimestamp).toBe('number');
+      expect(lastEventTimestamp).toBeLessThanOrEqual(Date.now());
     });
   });
 
   describe('startEventMonitoring', () => {
-    it('should start monitoring with default interval', () => {
+    it('should set isMonitoring to true', () => {
       eventListener.startEventMonitoring();
-
-      const status = eventListener.getStatus();
-      expect(status.isMonitoring).toBe(true);
+      expect(eventListener.getStatus().isMonitoring).toBe(true);
     });
 
-    it('should start monitoring with custom interval', () => {
-      eventListener.startEventMonitoring(10000);
-
-      const status = eventListener.getStatus();
-      expect(status.isMonitoring).toBe(true);
-    });
-
-    it('should broadcast runtime start event', () => {
+    it('should broadcast a runtime start event', () => {
       eventListener.startEventMonitoring();
-
       expect(mockSSEHandler.broadcast).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'runtime',
@@ -112,68 +92,26 @@ describe('NodeRedEventListener', () => {
       );
     });
 
-    it('should not start monitoring if already started', () => {
+    it('should not start again if already monitoring', () => {
       eventListener.startEventMonitoring();
-      const firstCallCount = mockSSEHandler.broadcast.mock.calls.length;
-
+      const callCount = mockSSEHandler.broadcast.mock.calls.length;
       eventListener.startEventMonitoring();
-      const secondCallCount = mockSSEHandler.broadcast.mock.calls.length;
-
-      // Should not have additional broadcasts
-      expect(secondCallCount).toBe(firstCallCount);
+      expect(mockSSEHandler.broadcast.mock.calls.length).toBe(callCount);
       expect(console.log).toHaveBeenCalledWith('Node-RED event monitoring already started');
-    });
-
-    it('should log the interval', () => {
-      eventListener.startEventMonitoring(5000);
-
-      expect(console.log).toHaveBeenCalledWith(
-        'Starting Node-RED event monitoring (interval: 5000ms)'
-      );
-    });
-
-    it('should poll for runtime events at specified interval', async () => {
-      eventListener.startEventMonitoring(1000);
-
-      // Clear initial broadcast call
-      mockSSEHandler.broadcast.mockClear();
-
-      // Advance timer to trigger polling
-      await vi.advanceTimersByTimeAsync(1000);
-
-      // Should have called healthCheck
-      expect(mockNodeRedClient.healthCheck).toHaveBeenCalled();
-    });
-
-    it('should poll for flow events at specified interval', async () => {
-      eventListener.startEventMonitoring(1000);
-
-      // Clear initial calls
-      mockNodeRedClient.getFlows.mockClear();
-
-      // Advance timer to trigger polling
-      await vi.advanceTimersByTimeAsync(1000);
-
-      // Should have called getFlows
-      expect(mockNodeRedClient.getFlows).toHaveBeenCalled();
     });
   });
 
   describe('stopEventMonitoring', () => {
-    it('should stop monitoring', () => {
+    it('should set isMonitoring to false', () => {
       eventListener.startEventMonitoring();
       eventListener.stopEventMonitoring();
-
-      const status = eventListener.getStatus();
-      expect(status.isMonitoring).toBe(false);
+      expect(eventListener.getStatus().isMonitoring).toBe(false);
     });
 
-    it('should broadcast runtime stop event', () => {
+    it('should broadcast a runtime stop event', () => {
       eventListener.startEventMonitoring();
       mockSSEHandler.broadcast.mockClear();
-
       eventListener.stopEventMonitoring();
-
       expect(mockSSEHandler.broadcast).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'runtime',
@@ -185,189 +123,21 @@ describe('NodeRedEventListener', () => {
       );
     });
 
-    it('should clear polling interval', async () => {
-      eventListener.startEventMonitoring(1000);
+    it('should be a no-op if not monitoring', () => {
       eventListener.stopEventMonitoring();
-
-      // Clear previous calls
-      mockNodeRedClient.healthCheck.mockClear();
-      mockNodeRedClient.getFlows.mockClear();
-
-      // Advance timer
-      await vi.advanceTimersByTimeAsync(2000);
-
-      // Should not have called healthCheck or getFlows after stop
-      expect(mockNodeRedClient.healthCheck).not.toHaveBeenCalled();
-      expect(mockNodeRedClient.getFlows).not.toHaveBeenCalled();
-    });
-
-    it('should not broadcast if not monitoring', () => {
-      eventListener.stopEventMonitoring();
-
       expect(mockSSEHandler.broadcast).not.toHaveBeenCalled();
     });
 
     it('should log when stopping', () => {
       eventListener.startEventMonitoring();
       eventListener.stopEventMonitoring();
-
       expect(console.log).toHaveBeenCalledWith('Stopping Node-RED event monitoring');
-    });
-  });
-
-  describe('event polling', () => {
-    it('should broadcast runtime status when healthy', async () => {
-      mockNodeRedClient.healthCheck.mockResolvedValue({ healthy: true });
-
-      eventListener.startEventMonitoring(1000);
-      mockSSEHandler.broadcast.mockClear();
-
-      await vi.advanceTimersByTimeAsync(1000);
-
-      expect(mockSSEHandler.broadcast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'runtime',
-          data: expect.objectContaining({
-            event: 'start',
-            message: 'Node-RED is running',
-          }),
-        })
-      );
-    });
-
-    it('should broadcast error status when unhealthy', async () => {
-      mockNodeRedClient.healthCheck.mockResolvedValue({ healthy: false });
-
-      eventListener.startEventMonitoring(1000);
-      mockSSEHandler.broadcast.mockClear();
-
-      await vi.advanceTimersByTimeAsync(1000);
-
-      expect(mockSSEHandler.broadcast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'runtime',
-          data: expect.objectContaining({
-            event: 'error',
-            message: 'Node-RED connection error',
-          }),
-        })
-      );
-    });
-
-    it('should broadcast error when healthCheck fails', async () => {
-      mockNodeRedClient.healthCheck.mockRejectedValue(new Error('Connection refused'));
-
-      eventListener.startEventMonitoring(1000);
-      mockSSEHandler.broadcast.mockClear();
-
-      await vi.advanceTimersByTimeAsync(1000);
-
-      expect(mockSSEHandler.broadcast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'error',
-          data: expect.objectContaining({
-            error: 'Runtime health check failed',
-          }),
-        })
-      );
-    });
-
-    it('should broadcast flow event after time threshold', async () => {
-      // Set last event timestamp to be old
-      const listener = eventListener as any;
-      listener.lastEventTimestamp = Date.now() - 120000; // 2 minutes ago
-
-      eventListener.startEventMonitoring(1000);
-      mockSSEHandler.broadcast.mockClear();
-
-      await vi.advanceTimersByTimeAsync(1000);
-
-      expect(mockSSEHandler.broadcast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'flow',
-          data: expect.objectContaining({
-            id: 'global',
-            event: 'start',
-            message: '2 flows are active',
-          }),
-        })
-      );
-    });
-
-    it('should not broadcast flow event within time threshold', async () => {
-      eventListener.startEventMonitoring(1000);
-
-      // Clear initial broadcast
-      mockSSEHandler.broadcast.mockClear();
-
-      await vi.advanceTimersByTimeAsync(1000);
-
-      // Should have runtime broadcast but no flow broadcast (within 1 minute)
-      const flowBroadcasts = mockSSEHandler.broadcast.mock.calls.filter(
-        call => call[0].type === 'flow'
-      );
-
-      expect(flowBroadcasts.length).toBe(0);
-    });
-
-    it('should broadcast flow error when getFlows fails', async () => {
-      mockNodeRedClient.getFlows.mockRejectedValue(new Error('Network error'));
-
-      // Set last event timestamp to be old to trigger flow check
-      const listener = eventListener as any;
-      listener.lastEventTimestamp = Date.now() - 120000;
-
-      eventListener.startEventMonitoring(1000);
-      mockSSEHandler.broadcast.mockClear();
-
-      await vi.advanceTimersByTimeAsync(1000);
-
-      expect(mockSSEHandler.broadcast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'flow',
-          data: expect.objectContaining({
-            id: 'global',
-            event: 'error',
-            message: 'Failed to get flow status',
-          }),
-        })
-      );
-    });
-
-    it('should handle polling errors gracefully', async () => {
-      mockNodeRedClient.healthCheck.mockRejectedValue(new Error('API error'));
-      mockNodeRedClient.getFlows.mockRejectedValue(new Error('API error'));
-
-      eventListener.startEventMonitoring(1000);
-
-      // Should not throw
-      await vi.advanceTimersByTimeAsync(1000);
-
-      expect(console.error).toHaveBeenCalled();
-    });
-
-    it('should broadcast error with details when polling fails', async () => {
-      const testError = new Error('Test polling error');
-      mockNodeRedClient.healthCheck.mockRejectedValue(testError);
-
-      eventListener.startEventMonitoring(1000);
-      mockSSEHandler.broadcast.mockClear();
-
-      await vi.advanceTimersByTimeAsync(1000);
-
-      // Should have broadcast an error event
-      expect(mockSSEHandler.broadcast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'error',
-        })
-      );
     });
   });
 
   describe('onFlowDeploy', () => {
     it('should broadcast flow deploy event with flowId', () => {
       eventListener.onFlowDeploy('flow-123');
-
       expect(mockSSEHandler.broadcast).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'flow',
@@ -382,7 +152,6 @@ describe('NodeRedEventListener', () => {
 
     it('should broadcast global deploy event without flowId', () => {
       eventListener.onFlowDeploy();
-
       expect(mockSSEHandler.broadcast).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'flow',
@@ -397,127 +166,79 @@ describe('NodeRedEventListener', () => {
 
     it('should include timestamp in event', () => {
       eventListener.onFlowDeploy('flow-1');
-
       expect(mockSSEHandler.broadcast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          timestamp: expect.any(String),
-        })
+        expect.objectContaining({ timestamp: expect.any(String) })
       );
     });
   });
 
   describe('onNodeStatus', () => {
     it('should broadcast node status event', () => {
-      eventListener.onNodeStatus('node-123', {
-        fill: 'green',
-        shape: 'dot',
-        text: 'Connected',
-      });
-
+      eventListener.onNodeStatus('node-123', { fill: 'green', shape: 'dot', text: 'Connected' });
       expect(mockSSEHandler.broadcast).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'status',
           data: expect.objectContaining({
             id: 'node-123',
-            status: expect.objectContaining({
-              fill: 'green',
-              shape: 'dot',
-              text: 'Connected',
-            }),
+            status: expect.objectContaining({ fill: 'green', shape: 'dot', text: 'Connected' }),
           }),
         })
       );
     });
 
     it('should broadcast status with partial fields', () => {
-      eventListener.onNodeStatus('node-456', {
-        fill: 'red',
-      });
-
+      eventListener.onNodeStatus('node-456', { fill: 'red' });
       expect(mockSSEHandler.broadcast).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'status',
-          data: expect.objectContaining({
-            id: 'node-456',
-            status: expect.objectContaining({
-              fill: 'red',
-            }),
-          }),
+          data: expect.objectContaining({ id: 'node-456' }),
         })
       );
     });
 
     it('should handle empty status object', () => {
       eventListener.onNodeStatus('node-789', {});
-
       expect(mockSSEHandler.broadcast).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'status',
-          data: expect.objectContaining({
-            id: 'node-789',
-          }),
+          data: expect.objectContaining({ id: 'node-789' }),
         })
       );
     });
 
     it('should include timestamp in event', () => {
       eventListener.onNodeStatus('node-123', { text: 'Test' });
-
       expect(mockSSEHandler.broadcast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          timestamp: expect.any(String),
-        })
+        expect.objectContaining({ timestamp: expect.any(String) })
       );
     });
   });
 
   describe('getStatus', () => {
     it('should return isMonitoring false when not started', () => {
-      const status = eventListener.getStatus();
-      expect(status.isMonitoring).toBe(false);
+      expect(eventListener.getStatus().isMonitoring).toBe(false);
     });
 
     it('should return isMonitoring true when started', () => {
       eventListener.startEventMonitoring();
-
-      const status = eventListener.getStatus();
-      expect(status.isMonitoring).toBe(true);
+      expect(eventListener.getStatus().isMonitoring).toBe(true);
     });
 
     it('should return isMonitoring false after stop', () => {
       eventListener.startEventMonitoring();
       eventListener.stopEventMonitoring();
-
-      const status = eventListener.getStatus();
-      expect(status.isMonitoring).toBe(false);
+      expect(eventListener.getStatus().isMonitoring).toBe(false);
     });
 
-    it('should return lastEventTimestamp', () => {
-      const status = eventListener.getStatus();
-      expect(status.lastEventTimestamp).toBeDefined();
-      expect(typeof status.lastEventTimestamp).toBe('number');
-      expect(status.lastEventTimestamp).toBeLessThanOrEqual(Date.now());
-    });
-
-    it('should update lastEventTimestamp after flow event', async () => {
-      // Set last event timestamp to be old
-      const listener = eventListener as any;
-      listener.lastEventTimestamp = Date.now() - 120000;
-
-      const initialTimestamp = listener.lastEventTimestamp;
-
-      eventListener.startEventMonitoring(1000);
-      await vi.advanceTimersByTimeAsync(1000);
-
-      const status = eventListener.getStatus();
-      expect(status.lastEventTimestamp).toBeGreaterThan(initialTimestamp);
+    it('should return a numeric lastEventTimestamp', () => {
+      const { lastEventTimestamp } = eventListener.getStatus();
+      expect(typeof lastEventTimestamp).toBe('number');
     });
   });
 
   describe('memory reporting', () => {
-    it('should include memory usage in runtime events', async () => {
-      eventListener.startEventMonitoring(1000);
-
+    it('should include memory usage in runtime start event', () => {
+      eventListener.startEventMonitoring();
       expect(mockSSEHandler.broadcast).toHaveBeenCalledWith(
         expect.objectContaining({
           type: 'runtime',
@@ -530,33 +251,6 @@ describe('NodeRedEventListener', () => {
           }),
         })
       );
-    });
-  });
-
-  describe('error handling', () => {
-    it('should handle non-Error objects in polling', async () => {
-      mockNodeRedClient.healthCheck.mockRejectedValue('string error');
-
-      eventListener.startEventMonitoring(1000);
-      mockSSEHandler.broadcast.mockClear();
-
-      await vi.advanceTimersByTimeAsync(1000);
-
-      // Should not throw and should broadcast error
-      expect(mockSSEHandler.broadcast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'error',
-        })
-      );
-    });
-
-    it('should log errors to console', async () => {
-      mockNodeRedClient.healthCheck.mockRejectedValue(new Error('Test error'));
-
-      eventListener.startEventMonitoring(1000);
-      await vi.advanceTimersByTimeAsync(1000);
-
-      expect(console.error).toHaveBeenCalled();
     });
   });
 });

--- a/src/services/nodered-event-listener.ts
+++ b/src/services/nodered-event-listener.ts
@@ -1,152 +1,67 @@
 /**
  * Node-RED Event Listener Service
- * Captures real-time events from Node-RED and forwards them through SSE
+ * Receives real-time events from Node-RED via WebSocket Comms API
+ * and forwards them through SSE to connected clients.
  */
 
 import { SSEHandler } from '../server/sse-handler.js';
 import {
-  NodeRedEvent,
   NodeRedFlowEvent,
   NodeRedNodeEvent,
   NodeRedRuntimeEvent,
-  NodeRedErrorEvent,
   NodeRedStatusEvent,
+  NodeRedErrorEvent,
 } from '../types/nodered.js';
-
 import { NodeRedAPIClient } from './nodered-api.js';
+import { NodeRedWsClient } from './nodered-ws-client.js';
 
 export class NodeRedEventListener {
   private sseHandler: SSEHandler;
-  private nodeRedClient: NodeRedAPIClient;
-  private eventPollingInterval?: NodeJS.Timeout | undefined;
+  private wsClient: NodeRedWsClient;
   private isMonitoring = false;
   private lastEventTimestamp: number = Date.now();
 
-  constructor(sseHandler: SSEHandler, nodeRedClient: NodeRedAPIClient) {
+  constructor(
+    sseHandler: SSEHandler,
+    nodeRedClient: NodeRedAPIClient,
+    wsClient?: NodeRedWsClient
+  ) {
     this.sseHandler = sseHandler;
-    this.nodeRedClient = nodeRedClient;
+    if (wsClient) {
+      this.wsClient = wsClient;
+    } else {
+      const baseURL =
+        (nodeRedClient as any).config?.baseURL ??
+        process.env.NODERED_URL ??
+        'http://localhost:1880';
+      this.wsClient = new NodeRedWsClient(sseHandler, {
+        baseURL,
+        onEvent: () => { this.lastEventTimestamp = Date.now(); },
+      });
+    }
   }
 
-  /**
-   * Start monitoring Node-RED events
-   */
-  startEventMonitoring(intervalMs = 5000): void {
+  startEventMonitoring(): void {
     if (this.isMonitoring) {
       console.log('Node-RED event monitoring already started');
       return;
     }
 
-    console.log(`Starting Node-RED event monitoring (interval: ${intervalMs}ms)`);
+    console.log('Starting Node-RED event monitoring (WebSocket)');
     this.isMonitoring = true;
-
-    // Poll for runtime status changes
-    this.eventPollingInterval = setInterval(async () => {
-      try {
-        await this.checkRuntimeEvents();
-        await this.checkFlowEvents();
-      } catch (error) {
-        console.error('Error checking Node-RED events:', error);
-        this.broadcastError(
-          'Failed to check Node-RED events',
-          error instanceof Error ? error.message : 'Unknown error'
-        );
-      }
-    }, intervalMs);
-
-    // Send initial runtime event
+    this.wsClient.connect();
     this.broadcastRuntimeEvent('start', 'Node-RED event monitoring started');
   }
 
-  /**
-   * Stop monitoring Node-RED events
-   */
   stopEventMonitoring(): void {
     if (!this.isMonitoring) return;
 
     console.log('Stopping Node-RED event monitoring');
     this.isMonitoring = false;
-
-    if (this.eventPollingInterval) {
-      clearInterval(this.eventPollingInterval);
-      this.eventPollingInterval = undefined;
-    }
-
+    this.wsClient.disconnect();
     this.broadcastRuntimeEvent('stop', 'Node-RED event monitoring stopped');
   }
 
-  /**
-   * Check for runtime status changes
-   */
-  private async checkRuntimeEvents(): Promise<void> {
-    try {
-      const health = await this.nodeRedClient.healthCheck();
-
-      // Broadcast system status if it changed
-      const statusEvent: NodeRedRuntimeEvent = {
-        type: 'runtime',
-        timestamp: new Date().toISOString(),
-        data: {
-          event: health.healthy ? 'start' : 'error',
-          message: health.healthy ? 'Node-RED is running' : 'Node-RED connection error',
-          memory: process.memoryUsage(),
-        },
-      };
-
-      this.sseHandler.broadcast(statusEvent);
-    } catch (error) {
-      this.broadcastError(
-        'Runtime health check failed',
-        error instanceof Error ? error.message : 'Unknown error'
-      );
-    }
-  }
-
-  /**
-   * Check for flow-related events
-   */
-  private async checkFlowEvents(): Promise<void> {
-    try {
-      // For now, we'll simulate flow events based on API calls
-      // In a real implementation, this would connect to Node-RED's event system
-
-      // Check if flows have been deployed recently
-      const flows = await this.nodeRedClient.getFlows();
-      const currentTimestamp = Date.now();
-
-      // Simple heuristic: if we can successfully get flows, consider it a "running" state
-      const flowEvent: NodeRedFlowEvent = {
-        type: 'flow',
-        timestamp: new Date().toISOString(),
-        data: {
-          id: 'global',
-          event: 'start',
-          message: `${flows.length} flows are active`,
-        },
-      };
-
-      // Only broadcast if significant time has passed since last event
-      if (currentTimestamp - this.lastEventTimestamp > 60000) {
-        // 1 minute
-        this.sseHandler.broadcast(flowEvent);
-        this.lastEventTimestamp = currentTimestamp;
-      }
-    } catch (error) {
-      const errorEvent: NodeRedFlowEvent = {
-        type: 'flow',
-        timestamp: new Date().toISOString(),
-        data: {
-          id: 'global',
-          event: 'error',
-          message: 'Failed to get flow status',
-        },
-      };
-      this.sseHandler.broadcast(errorEvent);
-    }
-  }
-
-  /**
-   * Broadcast Node-RED runtime event
-   */
   private broadcastRuntimeEvent(
     event: 'start' | 'stop' | 'restart' | 'error',
     message: string
@@ -160,34 +75,10 @@ export class NodeRedEventListener {
         memory: process.memoryUsage(),
       },
     };
-
     this.sseHandler.broadcast(runtimeEvent);
   }
 
-  /**
-   * Broadcast error event
-   */
-  private broadcastError(error: string, details?: string): void {
-    const errorEvent: NodeRedErrorEvent = {
-      type: 'error',
-      timestamp: new Date().toISOString(),
-      data: {
-        error,
-        source: {
-          id: 'event-listener',
-          type: 'service',
-          name: 'NodeRedEventListener',
-        },
-      },
-    };
-
-    this.sseHandler.broadcast(errorEvent);
-    console.error(`Node-RED Event Error: ${error}`, details);
-  }
-
-  /**
-   * Manually trigger flow deploy event
-   */
+  /** Manually signal a flow deploy (called from express-app on deploy endpoint). */
   onFlowDeploy(flowId?: string): void {
     const deployEvent: NodeRedFlowEvent = {
       type: 'flow',
@@ -198,14 +89,12 @@ export class NodeRedEventListener {
         message: flowId ? `Flow ${flowId} deployed` : 'All flows deployed',
       },
     };
-
     this.sseHandler.broadcast(deployEvent);
   }
 
-  /**
-   * Manually trigger node status event
-   */
+  /** Manually signal a node status update. */
   onNodeStatus(nodeId: string, status: { fill?: string; shape?: string; text?: string }): void {
+    this.lastEventTimestamp = Date.now();
     const statusEvent: NodeRedStatusEvent = {
       type: 'status',
       timestamp: new Date().toISOString(),
@@ -218,13 +107,9 @@ export class NodeRedEventListener {
         },
       },
     };
-
     this.sseHandler.broadcast(statusEvent);
   }
 
-  /**
-   * Get monitoring status
-   */
   getStatus(): { isMonitoring: boolean; lastEventTimestamp: number } {
     return {
       isMonitoring: this.isMonitoring,

--- a/src/services/nodered-ws-client.test.ts
+++ b/src/services/nodered-ws-client.test.ts
@@ -1,0 +1,250 @@
+/**
+ * NodeRedWsClient unit tests — uses a real in-process WS server via the 'ws' library.
+ */
+
+import { createServer } from 'http';
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WebSocketServer, WebSocket } from 'ws';
+
+import { SSEHandler } from '../server/sse-handler.js';
+
+import { NodeRedWsClient } from './nodered-ws-client.js';
+
+// Silence auth util so we control the token
+vi.mock('../utils/auth.js', () => ({
+  validateNodeRedAuth: vi.fn().mockReturnValue({ type: 'none' }),
+}));
+
+function makeSSEHandler(): { broadcast: ReturnType<typeof vi.fn> } {
+  return { broadcast: vi.fn() };
+}
+
+function startWsServer(): Promise<{ wss: WebSocketServer; port: number; close: () => Promise<void> }> {
+  return new Promise(resolve => {
+    const server = createServer();
+    const wss = new WebSocketServer({ server });
+    server.listen(0, () => {
+      const addr = server.address() as { port: number };
+      const close = () =>
+        new Promise<void>(res => {
+          wss.close(() => server.close(() => res()));
+        });
+      resolve({ wss, port: addr.port, close });
+    });
+  });
+}
+
+describe('NodeRedWsClient', () => {
+  let mockSSE: ReturnType<typeof makeSSEHandler>;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockSSE = makeSSEHandler();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('connects to a WS server and becomes connected', async () => {
+    const { wss, port, close } = await startWsServer();
+    const client = new NodeRedWsClient(mockSSE as unknown as SSEHandler, {
+      baseURL: `http://localhost:${port}`,
+    });
+
+    // Wait for the server to see the connection AND a tick for the 'open' handler to run
+    await new Promise<void>(resolve => {
+      wss.once('connection', () => setTimeout(resolve, 20));
+      client.connect();
+    });
+
+    expect(client.isConnected()).toBe(true);
+    client.disconnect();
+    await close();
+  });
+
+  it('broadcasts a status event for status/<nodeId> messages', async () => {
+    const { wss, port, close } = await startWsServer();
+    const client = new NodeRedWsClient(mockSSE as unknown as SSEHandler, {
+      baseURL: `http://localhost:${port}`,
+    });
+
+    await new Promise<void>(resolve => {
+      wss.once('connection', (ws: WebSocket) => {
+        ws.send(JSON.stringify({ topic: 'status/node-abc', data: { fill: 'green', shape: 'dot', text: 'ok' } }));
+        resolve();
+      });
+      client.connect();
+    });
+
+    // Wait for message to be processed
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(mockSSE.broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'status',
+        data: expect.objectContaining({
+          id: 'node-abc',
+          status: expect.objectContaining({ fill: 'green', text: 'ok' }),
+        }),
+      })
+    );
+
+    client.disconnect();
+    await close();
+  });
+
+  it('broadcasts a node event for debug messages', async () => {
+    const { wss, port, close } = await startWsServer();
+    const client = new NodeRedWsClient(mockSSE as unknown as SSEHandler, {
+      baseURL: `http://localhost:${port}`,
+    });
+
+    await new Promise<void>(resolve => {
+      wss.once('connection', (ws: WebSocket) => {
+        ws.send(JSON.stringify({ topic: 'debug', data: { id: 'node-debug', msg: 'hello' } }));
+        resolve();
+      });
+      client.connect();
+    });
+
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(mockSSE.broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'node',
+        data: expect.objectContaining({ id: 'node-debug', type: 'debug' }),
+      })
+    );
+
+    client.disconnect();
+    await close();
+  });
+
+  it('broadcasts a runtime event for notification/runtime-state', async () => {
+    const { wss, port, close } = await startWsServer();
+    const client = new NodeRedWsClient(mockSSE as unknown as SSEHandler, {
+      baseURL: `http://localhost:${port}`,
+    });
+
+    await new Promise<void>(resolve => {
+      wss.once('connection', (ws: WebSocket) => {
+        ws.send(JSON.stringify({ topic: 'notification/runtime-state', data: { state: 'stop' } }));
+        resolve();
+      });
+      client.connect();
+    });
+
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(mockSSE.broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'runtime',
+        data: expect.objectContaining({ event: 'stop' }),
+      })
+    );
+
+    client.disconnect();
+    await close();
+  });
+
+  it('broadcasts a node event for notification/node/added', async () => {
+    const { wss, port, close } = await startWsServer();
+    const client = new NodeRedWsClient(mockSSE as unknown as SSEHandler, {
+      baseURL: `http://localhost:${port}`,
+    });
+
+    await new Promise<void>(resolve => {
+      wss.once('connection', (ws: WebSocket) => {
+        ws.send(JSON.stringify({ topic: 'notification/node/added', data: { id: 'n1', type: 'inject' } }));
+        resolve();
+      });
+      client.connect();
+    });
+
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(mockSSE.broadcast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'node',
+        data: expect.objectContaining({ id: 'n1' }),
+      })
+    );
+
+    client.disconnect();
+    await close();
+  });
+
+  it('sends auth token on connect when bearer token is set', async () => {
+    const { validateNodeRedAuth } = await import('../utils/auth.js');
+    vi.mocked(validateNodeRedAuth).mockReturnValue({
+      type: 'bearer',
+      credentials: { token: 'my-token' },
+    });
+
+    const { wss, port, close } = await startWsServer();
+    const client = new NodeRedWsClient(mockSSE as unknown as SSEHandler, {
+      baseURL: `http://localhost:${port}`,
+    });
+
+    const receivedMessages: string[] = [];
+    await new Promise<void>(resolve => {
+      wss.once('connection', (ws: WebSocket) => {
+        ws.on('message', (msg: WebSocket.RawData) => {
+          receivedMessages.push(msg.toString());
+          resolve();
+        });
+      });
+      client.connect();
+    });
+
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(receivedMessages).toContain(JSON.stringify({ auth: 'my-token' }));
+
+    client.disconnect();
+    await close();
+  });
+
+  it('disconnect stops reconnect loop', async () => {
+    const client = new NodeRedWsClient(mockSSE as unknown as SSEHandler, {
+      baseURL: 'http://localhost:9', // nothing listening on port 9
+      maxReconnectDelay: 100,
+    });
+
+    client.connect();
+    await new Promise(r => setTimeout(r, 30));
+    client.disconnect();
+
+    const callCountAfterDisconnect = (mockSSE.broadcast as ReturnType<typeof vi.fn>).mock.calls.length;
+    await new Promise(r => setTimeout(r, 200));
+
+    // No new broadcasts after disconnect
+    expect((mockSSE.broadcast as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callCountAfterDisconnect);
+    expect(client.isConnected()).toBe(false);
+  });
+
+  it('ignores malformed messages', async () => {
+    const { wss, port, close } = await startWsServer();
+    const client = new NodeRedWsClient(mockSSE as unknown as SSEHandler, {
+      baseURL: `http://localhost:${port}`,
+    });
+
+    await new Promise<void>(resolve => {
+      wss.once('connection', (ws: WebSocket) => {
+        ws.send('not-valid-json');
+        resolve();
+      });
+      client.connect();
+    });
+
+    await new Promise(r => setTimeout(r, 50));
+    // Should not throw — broadcast may or may not be called for malformed input
+    expect(client.isConnected()).toBe(true);
+
+    client.disconnect();
+    await close();
+  });
+});

--- a/src/services/nodered-ws-client.ts
+++ b/src/services/nodered-ws-client.ts
@@ -1,0 +1,217 @@
+/**
+ * Node-RED WebSocket Comms client
+ * Connects to Node-RED's /comms endpoint for real-time push events.
+ */
+
+import WebSocket from 'ws';
+
+import { SSEHandler } from '../server/sse-handler.js';
+import {
+  NodeRedFlowEvent,
+  NodeRedNodeEvent,
+  NodeRedRuntimeEvent,
+  NodeRedStatusEvent,
+} from '../types/nodered.js';
+import { validateNodeRedAuth } from '../utils/auth.js';
+
+export interface NodeRedWsConfig {
+  baseURL: string;
+  maxReconnectDelay?: number;
+  onEvent?: () => void;
+}
+
+interface CommsMessage {
+  topic: string;
+  data?: any;
+}
+
+export class NodeRedWsClient {
+  private ws: WebSocket | null = null;
+  private sseHandler: SSEHandler;
+  private baseURL: string;
+  private maxReconnectDelay: number;
+  private reconnectDelay = 1000;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private connected = false;
+  private stopped = false;
+  private onEvent?: () => void;
+
+  constructor(sseHandler: SSEHandler, config: NodeRedWsConfig) {
+    this.sseHandler = sseHandler;
+    this.baseURL = config.baseURL;
+    this.maxReconnectDelay = config.maxReconnectDelay ?? 30000;
+    this.onEvent = config.onEvent;
+  }
+
+  connect(): void {
+    this.stopped = false;
+    this.reconnectDelay = 1000;
+    this._connect();
+  }
+
+  private _connect(): void {
+    if (this.stopped) return;
+
+    if (this.ws) {
+      this.ws.terminate();
+      this.ws = null;
+    }
+
+    const wsUrl =
+      this.baseURL
+        .replace(/^https:\/\//, 'wss://')
+        .replace(/^http:\/\//, 'ws://')
+        .replace(/\/$/, '') + '/comms';
+
+    try {
+      this.ws = new WebSocket(wsUrl, { rejectUnauthorized: false });
+    } catch (err) {
+      console.error('NodeRedWsClient: failed to create WebSocket', err);
+      this._scheduleReconnect();
+      return;
+    }
+
+    this.ws.on('open', () => {
+      this.connected = true;
+      this.reconnectDelay = 1000;
+      console.log(`NodeRedWsClient: connected to ${wsUrl}`);
+      this._sendAuth();
+    });
+
+    this.ws.on('message', (raw: WebSocket.RawData) => {
+      try {
+        const msg: CommsMessage = JSON.parse(raw.toString());
+        this._handleMessage(msg);
+      } catch {
+        // ignore malformed frames
+      }
+    });
+
+    this.ws.on('close', () => {
+      this.connected = false;
+      if (!this.stopped) {
+        console.log('NodeRedWsClient: disconnected, scheduling reconnect');
+        this._scheduleReconnect();
+      }
+    });
+
+    this.ws.on('error', err => {
+      // 'close' fires after 'error', which will trigger reconnect
+      console.error('NodeRedWsClient: error —', err.message);
+    });
+  }
+
+  private _sendAuth(): void {
+    const auth = validateNodeRedAuth();
+    if (auth.type === 'bearer' && auth.credentials?.token) {
+      this.ws!.send(JSON.stringify({ auth: auth.credentials.token }));
+    }
+    // basic auth has no WS equivalent — connect unauthenticated
+  }
+
+  private _scheduleReconnect(): void {
+    if (this.stopped) return;
+    const delay = this.reconnectDelay;
+    this.reconnectDelay = Math.min(this.reconnectDelay * 2, this.maxReconnectDelay);
+    this.reconnectTimer = setTimeout(() => this._connect(), delay);
+  }
+
+  private _handleMessage(msg: CommsMessage): void {
+    this.onEvent?.();
+    const { topic, data } = msg;
+    const timestamp = new Date().toISOString();
+
+    // Auth response
+    if (topic === 'auth') {
+      if (data === 'ok') {
+        console.log('NodeRedWsClient: auth ok');
+      } else if (data === 'fail') {
+        console.error('NodeRedWsClient: auth failed');
+      }
+      return;
+    }
+
+    // Node status: topic = "status/<nodeId>"
+    if (topic.startsWith('status/')) {
+      const nodeId = topic.slice('status/'.length);
+      const event: NodeRedStatusEvent = {
+        type: 'status',
+        timestamp,
+        data: {
+          id: nodeId,
+          status: {
+            fill: data?.fill,
+            shape: data?.shape,
+            text: data?.text,
+          },
+        },
+      };
+      this.sseHandler.broadcast(event);
+      return;
+    }
+
+    // Debug node output
+    if (topic === 'debug') {
+      const event: NodeRedNodeEvent = {
+        type: 'node',
+        timestamp,
+        data: {
+          id: data?.id ?? 'unknown',
+          type: 'debug',
+          event: 'output',
+          msg: data,
+        },
+      };
+      this.sseHandler.broadcast(event);
+      return;
+    }
+
+    // Runtime state change (deploy, start, stop)
+    if (topic === 'notification/runtime-state') {
+      const state: string = data?.state ?? 'unknown';
+      const event: NodeRedRuntimeEvent = {
+        type: 'runtime',
+        timestamp,
+        data: {
+          event: state === 'stop' ? 'stop' : state === 'start' ? 'start' : 'restart',
+          message: `Runtime state: ${state}`,
+        },
+      };
+      this.sseHandler.broadcast(event);
+      return;
+    }
+
+    // Node lifecycle: added, removed, enabled, disabled, upgraded, redeploy
+    if (topic.startsWith('notification/')) {
+      const action = topic.replace('notification/', '');
+      const event: NodeRedNodeEvent = {
+        type: 'node',
+        timestamp,
+        data: {
+          id: data?.id ?? 'unknown',
+          type: data?.type ?? 'unknown',
+          event: 'status',
+          msg: { action, ...data },
+        },
+      };
+      this.sseHandler.broadcast(event);
+    }
+  }
+
+  disconnect(): void {
+    this.stopped = true;
+    this.connected = false;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      this.ws.terminate();
+      this.ws = null;
+    }
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+}


### PR DESCRIPTION
## Summary

- **WebSocket Comms API**: Replaces 5-second HTTP polling with Node-RED's real-time `/comms` WebSocket endpoint — zero latency for status, debug, runtime, and node lifecycle events
- **Exponential backoff reconnect**: 1s → 30s cap with automatic recovery on disconnect
- **readOnlyHint annotations**: All 9 MCP tools annotated (`get_flows`, `get_flow`, `get_installed_modules`, `search_modules` = true; `create_flow`, `update_flow`, `enable_flow`, `disable_flow`, `install_module` = false)

## Changed files

| File | Change |
|------|--------|
| `src/services/nodered-ws-client.ts` | New — WebSocket client for `/comms` endpoint |
| `src/services/nodered-event-listener.ts` | Replaced polling interval with WS delegation |
| `src/server/express-app.ts` | Removed `_intervalMs` arg from `startEventMonitoring()` |
| `src/server/mcp-server.ts` | Added `annotations: { readOnlyHint }` to all 9 tools |
| `src/services/nodered-ws-client.test.ts` | New — 8 unit tests with real in-process WS server |
| `src/services/nodered-event-listener.test.ts` | Updated to use DI instead of module mocking |
| `package.json` | Added `ws` dependency |

## Test plan

- [ ] `yarn test` passes all unit tests (including new WS client tests)
- [ ] `yarn build` compiles without errors
- [ ] Deploy to `nodered.danielshaprvt.work` and confirm WS connects on startup
- [ ] Trigger a flow deploy in Node-RED UI — verify SSE clients receive the event in real time
- [ ] Kill Node-RED temporarily — verify client reconnects with backoff