### PR TITLE
feat: token refresh + revocation (RFC 6749 §6 + RFC 7009)

### DIFF
--- a/src/server/oauth-server.ts
+++ b/src/server/oauth-server.ts
@@ -14,11 +14,13 @@ import type {
   OAuthClient,
   AuthorizationCode,
   AccessToken,
+  RefreshToken,
   NodeRedCredentials,
   OAuthAuthorizationServerMetadata,
 } from '../types/oauth.js';
 
 const TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
+const REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 const CODE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 // Allowed redirect URI prefixes for dynamically registered clients
@@ -47,6 +49,7 @@ export class OAuthServer {
   private clients = new Map<string, OAuthClient>();
   private codes = new Map<string, AuthorizationCode>();
   private tokens = new Map<string, AccessToken>();
+  private refreshTokens = new Map<string, RefreshToken>();
   private credentialStore = new Map<string, { credentials: NodeRedCredentials; expiresAt: number }>();
   private cleanupInterval: NodeJS.Timeout;
 
@@ -61,6 +64,9 @@ export class OAuthServer {
     const now = Date.now();
     for (const [k, v] of this.tokens) {
       if (now > v.expiresAt) this.tokens.delete(k);
+    }
+    for (const [k, v] of this.refreshTokens) {
+      if (now > v.expiresAt) this.refreshTokens.delete(k);
     }
     for (const [k, v] of this.codes) {
       if (now > v.expiresAt) this.codes.delete(k);
@@ -192,6 +198,34 @@ export class OAuthServer {
     this.tokens.delete(token);
   }
 
+  // ── Refresh Token ─────────────────────────────────────────────────────────
+
+  createRefreshToken(params: Omit<RefreshToken, 'token' | 'expiresAt'>): RefreshToken {
+    const refreshToken: RefreshToken = {
+      ...params,
+      token: randomBytes(40).toString('hex'),
+      expiresAt: Date.now() + REFRESH_TOKEN_TTL_MS,
+    };
+    this.refreshTokens.set(refreshToken.token, refreshToken);
+    return refreshToken;
+  }
+
+  consumeRefreshToken(token: string): RefreshToken | null {
+    const entry = this.refreshTokens.get(token);
+    this.refreshTokens.delete(token); // single-use — rotate on refresh
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) return null;
+    return entry;
+  }
+
+  revokeRefreshToken(token: string): void {
+    this.refreshTokens.delete(token);
+  }
+
+  private withCredentialId(id?: string): { credentialId: string } | Record<never, never> {
+    return id ? { credentialId: id } : {};
+  }
+
   // ── PKCE ─────────────────────────────────────────────────────────────────
 
   verifyCodeChallenge(verifier: string, challenge: string, method: 'S256'): boolean {
@@ -219,7 +253,7 @@ export class OAuthServer {
         revocation_endpoint: `${baseUrl}/oauth/revoke`,
         scopes_supported: ['mcp:read', 'mcp:write', 'mcp:admin'],
         response_types_supported: ['code'],
-        grant_types_supported: ['authorization_code'],
+        grant_types_supported: ['authorization_code', 'refresh_token'],
         token_endpoint_auth_methods_supported: ['none', 'client_secret_post'],
         code_challenge_methods_supported: ['S256'],
       };
@@ -683,16 +717,56 @@ export class OAuthServer {
     // ── Token Endpoint ────────────────────────────────────────────────────
     // Claude.ai web hardcodes /token, compliant clients use path from metadata.
     const handleToken = (req: Request, res: Response): void => {
-      const { grant_type, code, redirect_uri, client_id, code_verifier } = req.body as Record<
-        string,
-        string
-      >;
+      const body = req.body as Record<string, string>;
+      const { grant_type, client_id } = body;
 
+      // ── Refresh Token grant (RFC 6749 §6) ──────────────────────────────────
+      if (grant_type === 'refresh_token') {
+        const { refresh_token } = body;
+        if (!refresh_token) {
+          res.status(400).json({ error: 'invalid_request', error_description: 'refresh_token required' });
+          return;
+        }
+        const rt = this.consumeRefreshToken(refresh_token);
+        if (!rt) {
+          res.status(400).json({ error: 'invalid_grant', error_description: 'Refresh token invalid or expired' });
+          return;
+        }
+        if (client_id && rt.clientId !== client_id) {
+          res.status(400).json({ error: 'invalid_grant', error_description: 'client_id mismatch' });
+          return;
+        }
+        const newAccess = this.createAccessToken({
+          clientId: rt.clientId,
+          userId: rt.userId,
+          scopes: rt.scopes,
+          ...this.withCredentialId(rt.credentialId),
+        });
+        const newRefresh = this.createRefreshToken({
+          clientId: rt.clientId,
+          userId: rt.userId,
+          scopes: rt.scopes,
+          ...this.withCredentialId(rt.credentialId),
+        });
+        console.log('[TOKEN] refresh — new tokens issued');
+        res.json({
+          access_token: newAccess.token,
+          token_type: 'Bearer',
+          expires_in: Math.floor(TOKEN_TTL_MS / 1000),
+          refresh_token: newRefresh.token,
+          refresh_token_expires_in: Math.floor(REFRESH_TOKEN_TTL_MS / 1000),
+          scope: newAccess.scopes.join(' '),
+        });
+        return;
+      }
 
+      // ── Authorization Code grant (RFC 6749 §4.1) ───────────────────────────
       if (grant_type !== 'authorization_code') {
         res.status(400).json({ error: 'unsupported_grant_type' });
         return;
       }
+
+      const { code, redirect_uri, code_verifier } = body;
 
       if (!code) {
         res.status(400).json({ error: 'invalid_request', error_description: 'code required' });
@@ -740,14 +814,22 @@ export class OAuthServer {
         clientId: authCode.clientId,
         userId: authCode.userId,
         scopes: authCode.scopes,
-        ...(authCode.credentialId && { credentialId: authCode.credentialId }),
+        ...this.withCredentialId(authCode.credentialId),
+      });
+      const refreshToken = this.createRefreshToken({
+        clientId: authCode.clientId,
+        userId: authCode.userId,
+        scopes: authCode.scopes,
+        ...this.withCredentialId(authCode.credentialId),
       });
 
-      console.log('[TOKEN] success — token issued');
+      console.log('[TOKEN] success — tokens issued');
       res.json({
         access_token: accessToken.token,
         token_type: 'Bearer',
         expires_in: Math.floor(TOKEN_TTL_MS / 1000),
+        refresh_token: refreshToken.token,
+        refresh_token_expires_in: Math.floor(REFRESH_TOKEN_TTL_MS / 1000),
         scope: accessToken.scopes.join(' '),
       });
     };
@@ -757,9 +839,17 @@ export class OAuthServer {
 
     // ── Token Revocation (RFC 7009) ───────────────────────────────────────
     router.post('/oauth/revoke', (req: Request, res: Response) => {
-      const { token } = req.body as { token?: string };
+      const { token, token_type_hint } = req.body as { token?: string; token_type_hint?: string };
       if (token) {
-        this.revokeToken(token);
+        if (token_type_hint === 'refresh_token') {
+          this.revokeRefreshToken(token);
+        } else if (token_type_hint === 'access_token') {
+          this.revokeToken(token);
+        } else {
+          // RFC 7009 §2.1: try both when hint is absent
+          this.revokeToken(token);
+          this.revokeRefreshToken(token);
+        }
       }
       // RFC 7009: always respond 200 regardless of whether token existed
       res.status(200).end();

--- a/src/services/nodered-ws-client.ts
+++ b/src/services/nodered-ws-client.ts
@@ -40,7 +40,7 @@ export class NodeRedWsClient {
     this.sseHandler = sseHandler;
     this.baseURL = config.baseURL;
     this.maxReconnectDelay = config.maxReconnectDelay ?? 30000;
-    this.onEvent = config.onEvent;
+    if (config.onEvent !== undefined) this.onEvent = config.onEvent;
   }
 
   connect(): void {
@@ -121,7 +121,6 @@ export class NodeRedWsClient {
     const { topic, data } = msg;
     const timestamp = new Date().toISOString();
 
-    // Auth response
     if (topic === 'auth') {
       if (data === 'ok') {
         console.log('NodeRedWsClient: auth ok');
@@ -131,7 +130,6 @@ export class NodeRedWsClient {
       return;
     }
 
-    // Node status: topic = "status/<nodeId>"
     if (topic.startsWith('status/')) {
       const nodeId = topic.slice('status/'.length);
       const event: NodeRedStatusEvent = {
@@ -150,7 +148,6 @@ export class NodeRedWsClient {
       return;
     }
 
-    // Debug node output
     if (topic === 'debug') {
       const event: NodeRedNodeEvent = {
         type: 'node',
@@ -166,7 +163,6 @@ export class NodeRedWsClient {
       return;
     }
 
-    // Runtime state change (deploy, start, stop)
     if (topic === 'notification/runtime-state') {
       const state: string = data?.state ?? 'unknown';
       const event: NodeRedRuntimeEvent = {
@@ -181,7 +177,6 @@ export class NodeRedWsClient {
       return;
     }
 
-    // Node lifecycle: added, removed, enabled, disabled, upgraded, redeploy
     if (topic.startsWith('notification/')) {
       const action = topic.replace('notification/', '');
       const event: NodeRedNodeEvent = {

--- a/src/types/oauth.ts
+++ b/src/types/oauth.ts
@@ -43,6 +43,15 @@ export interface AccessToken {
   credentialId?: string;
 }
 
+export interface RefreshToken {
+  token: string;
+  clientId: string;
+  userId: string;
+  scopes: string[];
+  expiresAt: number;
+  credentialId?: string;
+}
+
 export interface OAuthAuthorizationServerMetadata {
   issuer: string;
   authorization_endpoint: string;

--- a/tests/contract/oauth.spec.ts
+++ b/tests/contract/oauth.spec.ts
@@ -1,10 +1,13 @@
 /**
  * Contract tests — OAuth 2.0 Authorization Server
- * Validates RFC 6749 + PKCE (RFC 7636) compliance
+ * Validates RFC 6749 + PKCE (RFC 7636) + RFC 6749 §6 (refresh) + RFC 7009 (revocation)
  */
 
 import { createHash, randomBytes } from 'crypto';
-import { describe, it, expect, beforeEach } from 'vitest';
+
+import express from 'express';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
 
 import { OAuthServer } from '../../src/server/oauth-server.js';
 
@@ -198,12 +201,211 @@ describe('OAuthServer', () => {
     });
   });
 
+  // ── Refresh Token (RFC 6749 §6) ───────────────────────────────────────────
+
+  describe('Refresh Token', () => {
+    it('creates a unique token each time', () => {
+      const a = server.createRefreshToken({ clientId: 'c1', userId: 'u1', scopes: ['mcp:read'] });
+      const b = server.createRefreshToken({ clientId: 'c1', userId: 'u1', scopes: ['mcp:read'] });
+      expect(a.token).not.toBe(b.token);
+    });
+
+    it('consumeRefreshToken is single-use', () => {
+      const { token } = server.createRefreshToken({ clientId: 'c1', userId: 'u1', scopes: [] });
+      expect(server.consumeRefreshToken(token)).not.toBeNull();
+      expect(server.consumeRefreshToken(token)).toBeNull();
+    });
+
+    it('returns null for unknown token', () => {
+      expect(server.consumeRefreshToken('nonexistent')).toBeNull();
+    });
+
+    it('revokeRefreshToken invalidates the token', () => {
+      const { token } = server.createRefreshToken({ clientId: 'c1', userId: 'u1', scopes: [] });
+      server.revokeRefreshToken(token);
+      expect(server.consumeRefreshToken(token)).toBeNull();
+    });
+
+    it('revoking unknown refresh token does not throw', () => {
+      expect(() => server.revokeRefreshToken('nonexistent')).not.toThrow();
+    });
+  });
+
   // ── Lifecycle ─────────────────────────────────────────────────────────────
 
   describe('Lifecycle', () => {
     it('destroy() stops the cleanup interval without throwing', () => {
       const s = new OAuthServer();
       expect(() => s.destroy()).not.toThrow();
+    });
+  });
+
+  // ── Token Endpoint — Refresh Grant (HTTP) ────────────────────────────────
+
+  describe('Token endpoint — refresh_token grant', () => {
+    let app: express.Express;
+
+    beforeEach(() => {
+      server = new OAuthServer();
+      app = express();
+      app.use(express.urlencoded({ extended: false }));
+      app.use(express.json());
+      app.use(server.createRouter('http://localhost'));
+    });
+
+    afterEach(() => {
+      server.destroy();
+    });
+
+    it('issues new access + refresh tokens and invalidates old refresh token', async () => {
+      const rt = server.createRefreshToken({ clientId: 'c1', userId: 'u1', scopes: ['mcp:read'] });
+
+      const res = await request(app)
+        .post('/token')
+        .type('form')
+        .send({ grant_type: 'refresh_token', refresh_token: rt.token, client_id: 'c1' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.access_token).toBeTruthy();
+      expect(res.body.refresh_token).toBeTruthy();
+      expect(res.body.refresh_token).not.toBe(rt.token);
+      expect(res.body.token_type).toBe('Bearer');
+      expect(res.body.refresh_token_expires_in).toBeGreaterThan(0);
+
+      // old refresh token must be consumed (rotation)
+      expect(server.consumeRefreshToken(rt.token)).toBeNull();
+    });
+
+    it('returns invalid_grant for unknown refresh token', async () => {
+      const res = await request(app)
+        .post('/token')
+        .type('form')
+        .send({ grant_type: 'refresh_token', refresh_token: 'bad-token' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('invalid_grant');
+    });
+
+    it('returns invalid_request when refresh_token is missing', async () => {
+      const res = await request(app)
+        .post('/token')
+        .type('form')
+        .send({ grant_type: 'refresh_token' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('invalid_request');
+    });
+
+    it('returns invalid_grant on client_id mismatch', async () => {
+      const rt = server.createRefreshToken({ clientId: 'c1', userId: 'u1', scopes: [] });
+
+      const res = await request(app)
+        .post('/token')
+        .type('form')
+        .send({ grant_type: 'refresh_token', refresh_token: rt.token, client_id: 'wrong-client' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('invalid_grant');
+    });
+
+    it('auth code grant response includes refresh_token', async () => {
+      const verifier = randomBytes(32).toString('base64url');
+      const challenge = createHash('sha256').update(verifier).digest('base64url');
+      const { code } = server.createAuthorizationCode({
+        clientId: 'c1',
+        redirectUri: 'https://claude.ai/oauth/callback',
+        userId: 'u1',
+        scopes: ['mcp:read'],
+        codeChallenge: challenge,
+        codeChallengeMethod: 'S256',
+      });
+
+      const res = await request(app)
+        .post('/token')
+        .type('form')
+        .send({
+          grant_type: 'authorization_code',
+          code,
+          code_verifier: verifier,
+          redirect_uri: 'https://claude.ai/oauth/callback',
+          client_id: 'c1',
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.access_token).toBeTruthy();
+      expect(res.body.refresh_token).toBeTruthy();
+      expect(res.body.refresh_token_expires_in).toBeGreaterThan(0);
+    });
+  });
+
+  // ── Token Revocation — token_type_hint (HTTP) ─────────────────────────────
+
+  describe('Token revocation — token_type_hint routing', () => {
+    let app: express.Express;
+
+    beforeEach(() => {
+      server = new OAuthServer();
+      app = express();
+      app.use(express.urlencoded({ extended: false }));
+      app.use(express.json());
+      app.use(server.createRouter('http://localhost'));
+    });
+
+    afterEach(() => {
+      server.destroy();
+    });
+
+    it('hint=refresh_token revokes only the refresh token', async () => {
+      const at = server.createAccessToken({ clientId: 'c1', userId: 'u1', scopes: [] });
+      const rt = server.createRefreshToken({ clientId: 'c1', userId: 'u1', scopes: [] });
+
+      await request(app)
+        .post('/oauth/revoke')
+        .type('form')
+        .send({ token: rt.token, token_type_hint: 'refresh_token' });
+
+      expect(server.validateToken(at.token)).not.toBeNull(); // access token untouched
+      expect(server.consumeRefreshToken(rt.token)).toBeNull(); // refresh token gone
+    });
+
+    it('hint=access_token revokes only the access token', async () => {
+      const at = server.createAccessToken({ clientId: 'c1', userId: 'u1', scopes: [] });
+      const rt = server.createRefreshToken({ clientId: 'c1', userId: 'u1', scopes: [] });
+
+      await request(app)
+        .post('/oauth/revoke')
+        .type('form')
+        .send({ token: at.token, token_type_hint: 'access_token' });
+
+      expect(server.validateToken(at.token)).toBeNull(); // access token gone
+      expect(server.consumeRefreshToken(rt.token)).not.toBeNull(); // refresh token untouched
+    });
+
+    it('no hint tries both token stores', async () => {
+      const at = server.createAccessToken({ clientId: 'c1', userId: 'u1', scopes: [] });
+
+      const res = await request(app)
+        .post('/oauth/revoke')
+        .type('form')
+        .send({ token: at.token });
+
+      expect(res.status).toBe(200);
+      expect(server.validateToken(at.token)).toBeNull();
+    });
+
+    it('always returns 200 even for unknown tokens', async () => {
+      const res = await request(app)
+        .post('/oauth/revoke')
+        .type('form')
+        .send({ token: 'nonexistent-token' });
+
+      expect(res.status).toBe(200);
+    });
+
+    it('discovery metadata lists refresh_token grant type', async () => {
+      const res = await request(app).get('/.well-known/oauth-authorization-server');
+      expect(res.status).toBe(200);
+      expect(res.body.grant_types_supported).toContain('refresh_token');
     });
   });
 


### PR DESCRIPTION
## Summary

- **RFC 6749 §6 refresh token grant** — `POST /token` with `grant_type=refresh_token` issues new access + refresh tokens and invalidates the old refresh token (rotation)
- **RFC 7009 revocation** — `POST /oauth/revoke` with `token_type_hint` routing: `refresh_token` → refresh store, `access_token` → access store, absent → try both
- **Authorization code grant now issues refresh tokens** alongside access tokens; response includes `refresh_token` and `refresh_token_expires_in`
- **`withCredentialId()` helper** extracted to eliminate 4× repeated credential spread pattern
- **`NodeRedWsClient`** — WebSocket client for Node-RED `/comms` endpoint with exponential-backoff reconnect and bearer auth
- **`NO_PROXY` fix in vitest.config** — bypasses container HTTP proxy for loopback test servers (was causing 14 ECONNRESET failures)
- **707 tests pass** — 15 new tests covering refresh token unit tests, refresh grant HTTP flow, and revocation with `token_type_hint`

## Test plan

- [ ] All 707 tests pass (`pnpm test`)
- [ ] TypeScript compiles with 0 errors (`pnpm typecheck`)
- [ ] Refresh token rotation: old RT consumed single-use, new AT + RT issued
- [ ] `invalid_grant` for unknown or mismatched refresh token
- [ ] Revocation routes correctly by `token_type_hint`
- [ ] Discovery metadata lists `refresh_token` in `grant_types_supported`