### PR TITLE
fix: Basic auth for nginx-protected Node-RED (remove broken OAuth)

### DIFF
--- a/src/services/nodered-api.ts
+++ b/src/services/nodered-api.ts
@@ -18,7 +18,7 @@ import {
   NodeRedDeploymentOptions,
   NodeRedAPIError,
 } from '../types/nodered.js';
-// getNodeRedAuthHeader removed — auth is now handled via OAuth Bearer token interceptor
+import { getNodeRedAuthHeader } from '../utils/auth.js';
 import { handleNodeRedError } from '../utils/error-handling.js';
 import { CircuitBreaker, retryWithCircuitBreaker, type RetryOptions } from '../utils/retry.js';
 
@@ -59,8 +59,6 @@ export class NodeRedAPIClient {
   private config: NodeRedAPIConfig;
   private circuitBreaker: CircuitBreaker;
   private retryOptions: RetryOptions;
-  private bearerToken: string | null = null;
-  private tokenFetchPromise: Promise<void> | null = null;
 
   constructor(config: Partial<NodeRedAPIConfig> = {}) {
     this.config = {
@@ -112,6 +110,7 @@ export class NodeRedAPIClient {
       httpsAgent: new https.Agent({ rejectUnauthorized: false }),
       headers: {
         'Content-Type': 'application/json',
+        ...getNodeRedAuthHeader(),
         ...this.config.headers,
       },
     });
@@ -119,44 +118,6 @@ export class NodeRedAPIClient {
     this.setupInterceptors();
   }
 
-  private async ensureAuthenticated(): Promise<void> {
-    // Static API token takes precedence — no login needed
-    const staticToken = process.env.NODERED_API_TOKEN;
-    if (staticToken) {
-      this.bearerToken = staticToken;
-      return;
-    }
-    if (this.bearerToken) return;
-
-    const username = process.env.NODERED_USERNAME;
-    const password = process.env.NODERED_PASSWORD;
-    if (!username || !password) return;
-
-    // Prevent concurrent login attempts
-    if (this.tokenFetchPromise) {
-      await this.tokenFetchPromise;
-      return;
-    }
-
-    this.tokenFetchPromise = (async () => {
-      try {
-        const response = await this.client.post<{ access_token: string }>(
-          '/auth/token',
-          { client_id: 'node-red-admin', grant_type: 'password', username, password },
-          { headers: { 'x-skip-nodered-auth': '1' } }
-        );
-        this.bearerToken = response.data.access_token;
-      } catch (err) {
-        console.error('Node-RED OAuth login failed:', err instanceof Error ? err.message : err);
-      }
-    })();
-
-    try {
-      await this.tokenFetchPromise;
-    } finally {
-      this.tokenFetchPromise = null;
-    }
-  }
   /**
    * Validate that response contains JSON, not HTML
    */
@@ -190,18 +151,8 @@ export class NodeRedAPIClient {
    * Setup axios interceptors for retries and error handling
    */
   private setupInterceptors(): void {
-    // Request interceptor: inject Bearer token (skip for the login call itself)
     this.client.interceptors.request.use(
-      async config => {
-        if (!config.headers?.['x-skip-nodered-auth']) {
-          await this.ensureAuthenticated();
-          if (this.bearerToken) {
-            config.headers = config.headers || {};
-            config.headers.Authorization = `Bearer ${this.bearerToken}`;
-          }
-        }
-        return config;
-      },
+      config => config,
       error => Promise.reject(error)
     );
 
@@ -229,42 +180,14 @@ export class NodeRedAPIClient {
         }
         return response;
       },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      async (error: any) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      async error => {
         const config = error.config;
 
-        // On 401, clear cached token and retry once to re-authenticate
-        if (
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          error.response?.status === 401 &&
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          !config._authRetried &&
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          !config.headers?.['x-skip-nodered-auth']
-        ) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          config._authRetried = true;
-          this.bearerToken = null;
-          await this.ensureAuthenticated();
-          if (this.bearerToken) {
-            const token = this.bearerToken;
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/restrict-template-expressions
-            config.headers.Authorization = `Bearer ${token}`;
-
-            return this.client(config);
-          }
-        }
-
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         if (!config._retry && config._retryCount < this.config.retries) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           config._retry = true;
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
           config._retryCount = (config._retryCount || 0) + 1;
 
           // Exponential backoff
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument
           const delay = Math.pow(2, config._retryCount) * 1000;
           await new Promise(resolve => setTimeout(resolve, delay));
 

--- a/src/services/nodered-ws-client.ts
+++ b/src/services/nodered-ws-client.ts
@@ -3,9 +3,6 @@
  * Connects to Node-RED's /comms endpoint for real-time push events.
  */
 
-import https from 'https';
-
-import axios from 'axios';
 import WebSocket from 'ws';
 
 import { SSEHandler } from '../server/sse-handler.js';
@@ -15,7 +12,7 @@ import {
   NodeRedRuntimeEvent,
   NodeRedStatusEvent,
 } from '../types/nodered.js';
-import { validateNodeRedAuth } from '../utils/auth.js';
+import { getNodeRedAuthHeader } from '../utils/auth.js';
 
 export interface NodeRedWsConfig {
   baseURL: string;
@@ -38,23 +35,6 @@ export class NodeRedWsClient {
   private connected = false;
   private stopped = false;
   private onEvent?: () => void;
-  private accessToken: string | null = null;
-
-  private async fetchOAuthToken(): Promise<string | null> {
-    const username = process.env.NODERED_USERNAME;
-    const password = process.env.NODERED_PASSWORD;
-    if (!username || !password) return null;
-    try {
-      const resp = await axios.post<{ access_token: string }>(
-        `${this.baseURL}/auth/token`,
-        { client_id: 'node-red-admin', grant_type: 'password', username, password },
-        { httpsAgent: new https.Agent({ rejectUnauthorized: false }) }
-      );
-      return resp.data.access_token;
-    } catch {
-      return null;
-    }
-  }
 
   constructor(sseHandler: SSEHandler, config: NodeRedWsConfig) {
     this.sseHandler = sseHandler;
@@ -71,35 +51,23 @@ export class NodeRedWsClient {
 
   private _connect(): void {
     if (this.stopped) return;
-    // Fetch OAuth token before connecting, then proceed
-    void this._connectWithAuth();
-  }
-
-  private async _connectWithAuth(): Promise<void> {
-    if (this.stopped) return;
 
     if (this.ws) {
       this.ws.terminate();
       this.ws = null;
     }
 
-    // Obtain OAuth token for handshake (clears on 401 to force re-login)
-    if (!this.accessToken) {
-      this.accessToken = await this.fetchOAuthToken();
-    }
-
-    const wsUrl = `${this.baseURL
-      .replace(/^https:\/\//, 'wss://')
-      .replace(/^http:\/\//, 'ws://')
-      .replace(/\/$/, '')}/comms`;
-
-    const wsOpts: WebSocket.ClientOptions = { rejectUnauthorized: false };
-    if (this.accessToken) {
-      wsOpts.headers = { Authorization: `Bearer ${this.accessToken}` };
-    }
+    const wsUrl =
+      this.baseURL
+        .replace(/^https:\/\//, 'wss://')
+        .replace(/^http:\/\//, 'ws://')
+        .replace(/\/$/, '') + '/comms';
 
     try {
-      this.ws = new WebSocket(wsUrl, wsOpts);
+      this.ws = new WebSocket(wsUrl, {
+        rejectUnauthorized: false,
+        headers: getNodeRedAuthHeader(),
+      });
     } catch (err) {
       console.error('NodeRedWsClient: failed to create WebSocket', err);
       this._scheduleReconnect();
@@ -110,7 +78,6 @@ export class NodeRedWsClient {
       this.connected = true;
       this.reconnectDelay = 1000;
       console.log(`NodeRedWsClient: connected to ${wsUrl}`);
-      this._sendAuth();
     });
 
     this.ws.on('message', (raw: WebSocket.RawData) => {
@@ -132,20 +99,9 @@ export class NodeRedWsClient {
     });
 
     this.ws.on('error', err => {
-      // On 401, clear the cached token so reconnect will re-authenticate
-      if (err.message.includes('401')) {
-        this.accessToken = null;
-      }
+      // 'close' fires after 'error', which will trigger reconnect
       console.error('NodeRedWsClient: error —', err.message);
     });
-  }
-
-  private _sendAuth(): void {
-    const auth = validateNodeRedAuth();
-    if (auth.type === 'bearer' && auth.credentials?.token) {
-      this.ws!.send(JSON.stringify({ auth: auth.credentials.token }));
-    }
-    // basic auth has no WS equivalent — connect unauthenticated
   }
 
   private _scheduleReconnect(): void {


### PR DESCRIPTION
## What

The `ensureAuthenticated()` OAuth flow added in `4ebd492` has been failing since day one — every 30 seconds, two 401 errors in the logs.

## Root cause

The Node-RED instance at `https://192.168.68.121:1880` sits behind **nginx** which requires HTTP Basic auth (`Authorization: Basic ...`). The OAuth password-grant to `/auth/token` was being blocked by nginx before it even reached Node-RED, returning a plain nginx 401 page.

Verified from inside the container:
- `curl -u user:pass https://192.168.68.121:1880/flows` → **200** ✅
- `curl https://192.168.68.121:1880/auth/token` (OAuth grant) → **401** ❌

## Changes

- **`nodered-api.ts`**: remove `ensureAuthenticated()`, `bearerToken`, `tokenFetchPromise`; restore `getNodeRedAuthHeader()` on the axios instance (sends Basic auth header on every request)
- **`nodered-ws-client.ts`**: remove `fetchOAuthToken()`, `_connectWithAuth()`, `accessToken`; pass `getNodeRedAuthHeader()` in WebSocket handshake options so nginx accepts the upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)