### PR TITLE
fix: configurable TLS certificate validation (CodeQL)

### DIFF
--- a/src/services/nodered-api.ts
+++ b/src/services/nodered-api.ts
@@ -18,7 +18,7 @@ import {
   NodeRedDeploymentOptions,
   NodeRedAPIError,
 } from '../types/nodered.js';
-import { getNodeRedAuthHeader } from '../utils/auth.js';
+import { getNodeRedAuthHeader, getTlsRejectUnauthorized } from '../utils/auth.js';
 import { handleNodeRedError } from '../utils/error-handling.js';
 import { CircuitBreaker, retryWithCircuitBreaker, type RetryOptions } from '../utils/retry.js';
 
@@ -106,8 +106,7 @@ export class NodeRedAPIClient {
     this.client = axios.create({
       baseURL: this.config.baseURL,
       timeout: this.config.timeout,
-      // Allow self-signed certs for local HAOS/homelab HTTPS endpoints
-      httpsAgent: new https.Agent({ rejectUnauthorized: false }),
+      httpsAgent: new https.Agent({ rejectUnauthorized: getTlsRejectUnauthorized() }),
       headers: {
         'Content-Type': 'application/json',
         ...getNodeRedAuthHeader(),

--- a/src/services/nodered-ws-client.ts
+++ b/src/services/nodered-ws-client.ts
@@ -12,7 +12,7 @@ import {
   NodeRedRuntimeEvent,
   NodeRedStatusEvent,
 } from '../types/nodered.js';
-import { getNodeRedAuthHeader } from '../utils/auth.js';
+import { getNodeRedAuthHeader, getTlsRejectUnauthorized } from '../utils/auth.js';
 
 export interface NodeRedWsConfig {
   baseURL: string;
@@ -65,7 +65,7 @@ export class NodeRedWsClient {
 
     try {
       this.ws = new WebSocket(wsUrl, {
-        rejectUnauthorized: false,
+        rejectUnauthorized: getTlsRejectUnauthorized(),
         headers: getNodeRedAuthHeader(),
       });
     } catch (err) {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -249,6 +249,11 @@ export function validateNodeRedAuth(): {
 /**
  * Generate Node-RED authorization header
  */
+
+export function getTlsRejectUnauthorized(): boolean {
+  return process.env.NODERED_TLS_REJECT_UNAUTHORIZED !== 'false';
+}
+
 export function getNodeRedAuthHeader(): Record<string, string> {
   const authConfig = validateNodeRedAuth();
 


### PR DESCRIPTION
## What

Replaces hardcoded `rejectUnauthorized: false` with an env-based toggle to satisfy CodeQL security scan.

## Changes

- `auth.ts`: add `getTlsRejectUnauthorized()` — returns `true` by default, `false` when `NODERED_TLS_REJECT_UNAUTHORIZED=false`
- `nodered-ws-client.ts`: use `getTlsRejectUnauthorized()` in WebSocket handshake options
- `nodered-api.ts`: use `getTlsRejectUnauthorized()` in axios https agent

## Deployment

The production container already needs self-signed cert support (HA nginx). Add `NODERED_TLS_REJECT_UNAUTHORIZED=false` to the container env to preserve current behavior.