### PR TITLE
feat: add HTTP Basic auth to MCP server

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -6,6 +6,10 @@ NODERED_URL=https://nodered.danielshaprvt.work
 # Public URL of this MCP server — used in OAuth discovery
 PUBLIC_URL=https://mcp.danielshaprvt.work
 
+# MCP server Basic auth (for NanoClaw / programmatic access)
+MCP_USERNAME=CHANGE_ME
+MCP_PASSWORD=CHANGE_ME
+
 # JWT secret — generate with: openssl rand -hex 32
 JWT_SECRET=CHANGE_ME_generate_with_openssl_rand_hex_32
 

--- a/src/services/nodered-api.test.ts
+++ b/src/services/nodered-api.test.ts
@@ -58,6 +58,7 @@ vi.mock('axios', () => {
 // Mock auth utility
 vi.mock('../utils/auth.js', () => ({
   getNodeRedAuthHeader: vi.fn(() => ({})),
+  getTlsRejectUnauthorized: vi.fn(() => true),
 }));
 
 describe('NodeRedAPIClient', () => {

--- a/src/services/nodered-ws-client.test.ts
+++ b/src/services/nodered-ws-client.test.ts
@@ -15,6 +15,7 @@ import { NodeRedWsClient } from './nodered-ws-client.js';
 // Silence auth util so we control what headers are returned
 vi.mock('../utils/auth.js', () => ({
   getNodeRedAuthHeader: vi.fn().mockReturnValue({}),
+  getTlsRejectUnauthorized: vi.fn().mockReturnValue(true),
 }));
 
 function makeSSEHandler(): { broadcast: ReturnType<typeof vi.fn> } {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -143,7 +143,65 @@ export function authenticateAPIKey(req: AuthRequest, res: Response, next: NextFu
 }
 
 /**
- * Flexible authentication middleware (JWT or API key)
+ * Middleware for HTTP Basic authentication (MCP_USERNAME / MCP_PASSWORD env vars)
+ */
+export function authenticateBasic(req: AuthRequest, res: Response, next: NextFunction): void {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader?.startsWith('Basic ')) {
+    res.status(401).json({ error: 'Basic authentication required' });
+    return;
+  }
+
+  const decoded = Buffer.from(authHeader.slice(6), 'base64').toString();
+  const colonIndex = decoded.indexOf(':');
+  if (colonIndex === -1) {
+    res.status(401).json({ error: 'Invalid Basic auth format' });
+    return;
+  }
+
+  const username = decoded.slice(0, colonIndex);
+  const password = decoded.slice(colonIndex + 1);
+
+  const expectedUsername = process.env.MCP_USERNAME;
+  const expectedPassword = process.env.MCP_PASSWORD;
+
+  if (!expectedUsername || !expectedPassword) {
+    res.status(401).json({ error: 'Basic auth not configured' });
+    return;
+  }
+
+  let valid = false;
+  try {
+    const u = Buffer.from(username);
+    const eu = Buffer.from(expectedUsername);
+    const p = Buffer.from(password);
+    const ep = Buffer.from(expectedPassword);
+    valid =
+      u.length === eu.length &&
+      p.length === ep.length &&
+      timingSafeEqual(u, eu) &&
+      timingSafeEqual(p, ep);
+  } catch {
+    valid = false;
+  }
+
+  if (!valid) {
+    res.status(401).json({ error: 'Invalid credentials' });
+    return;
+  }
+
+  req.auth = {
+    userId: username,
+    permissions: ['*'],
+    isAuthenticated: true,
+  };
+
+  next();
+}
+
+/**
+ * Flexible authentication middleware (JWT, API key, or Basic)
  */
 export function authenticate(req: AuthRequest, res: Response, next: NextFunction): void {
   const authHeader = req.headers.authorization;
@@ -151,6 +209,10 @@ export function authenticate(req: AuthRequest, res: Response, next: NextFunction
 
   if (apiKey) {
     return authenticateAPIKey(req, res, next);
+  }
+
+  if (authHeader?.startsWith('Basic ')) {
+    return authenticateBasic(req, res, next);
   }
 
   if (authHeader) {


### PR DESCRIPTION
## Summary
- Adds `authenticateBasic()` middleware to `src/utils/auth.ts` — validates `MCP_USERNAME` / `MCP_PASSWORD` env vars using timing-safe comparison
- Updates `authenticate()` to dispatch to Basic when `Authorization: Basic` is present (before JWT)
- Fixes `nodered-ws-client.test.ts` and `nodered-api.test.ts` mocks to include `getTlsRejectUnauthorized` (added in PR #81 but missing from test mocks) — resolves timeout failures
- Documents `MCP_USERNAME` / `MCP_PASSWORD` in `.env.prod.example`

## Test plan
- [ ] All 707 tests pass (`yarn test`)
- [ ] Lint clean (`yarn lint`)
- [ ] After merge: add `MCP_USERNAME` and `MCP_PASSWORD` to container env vars and recreate

🤖 Generated with [Claude Code](https://claude.com/claude-code)