### PR TITLE
feat: add Basic auth support to MCP endpoint

### DIFF
--- a/src/server/express-app.ts
+++ b/src/server/express-app.ts
@@ -9,7 +9,7 @@ import helmet from 'helmet';
 
 import { NodeRedEventListener } from '../services/nodered-event-listener.js';
 import type { ApiResponse } from '../types/mcp-extensions.js';
-import { authenticate, authenticateAPIKey, verifyToken, getRateLimitKey } from '../utils/auth.js';
+import { authenticate, authenticateAPIKey, authenticateBasic, verifyToken, getRateLimitKey } from '../utils/auth.js';
 import type { AuthRequest } from '../utils/auth.js';
 import {
   errorHandler,
@@ -89,6 +89,10 @@ export class ExpressApp {
     }
 
     const authHeader = req.headers.authorization;
+    if (authHeader?.startsWith('Basic ')) {
+      return authenticateBasic(req as AuthRequest, res, next);
+    }
+
     if (authHeader?.startsWith('Bearer ')) {
       const token = authHeader.slice(7);
 


### PR DESCRIPTION
Extends the `requireAuth` middleware on `/mcp` to also accept HTTP Basic auth credentials (`MCP_USERNAME`/`MCP_PASSWORD`).

Previously, only API Key and Bearer (OAuth/JWT) worked on the MCP endpoint. Basic auth was supported only on `/api/*` routes.

This allows programmatic agents (NanoClaw, scripts) to connect directly with Basic auth — no OAuth UI flow required.