### PR TITLE
fix: bind server to 0.0.0.0 by default instead of localhost

### DIFF
--- a/src/server/express-app.ts
+++ b/src/server/express-app.ts
@@ -62,7 +62,7 @@ export class ExpressApp {
 
     this.config = {
       port: parseInt(process.env.PORT || '3000'),
-      host: process.env.HOST || 'localhost',
+      host: process.env.HOST || '0.0.0.0',
       cors: {
         origin: process.env.CORS_ORIGIN?.split(',') || [
           'https://claude.ai',


### PR DESCRIPTION
## Summary

- Fixes a container networking bug where the server bound to `localhost` (127.0.0.1) instead of all interfaces
- Without this fix, Traefik and other services on the Docker network cannot reach the container
- The README already documented `0.0.0.0` as the default — this aligns the code to match

## Impact

This was discovered when deploying the updated GHCR image to production: Traefik returned 502 because it could resolve the service DNS name but the connection was refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)