### PR TITLE
feat: add search_flows MCP tool (Feature 5)

### DIFF
--- a/src/server/mcp-server.test.ts
+++ b/src/server/mcp-server.test.ts
@@ -568,7 +568,9 @@ describe('McpNodeRedServer', () => {
       const parsed = JSON.parse(result.content[0].text);
 
       expect(parsed.success).toBe(true);
-      expect(parsed.data.matches.every((m: any) => m.nodeType.toLowerCase().includes('mqtt'))).toBe(true);
+      expect(parsed.data.matches.every((m: any) => m.nodeType.toLowerCase().includes('mqtt'))).toBe(
+        true
+      );
       expect(parsed.data.total).toBe(1);
     });
 

--- a/src/server/mcp-server.test.ts
+++ b/src/server/mcp-server.test.ts
@@ -251,9 +251,20 @@ describe('McpNodeRedServer', () => {
       expect(getInstalledTool?.inputSchema.required).toEqual([]);
     });
 
-    it('should have exactly 12 tools defined', () => {
+    it('should include search_flows tool', () => {
       const tools = mcpServer.getToolDefinitions();
-      expect(tools.length).toBe(12);
+      const searchFlowsTool = tools.find(t => t.name === 'search_flows');
+
+      expect(searchFlowsTool).toBeDefined();
+      expect(searchFlowsTool?.annotations?.readOnlyHint).toBe(true);
+      expect(searchFlowsTool?.inputSchema.properties).toHaveProperty('type');
+      expect(searchFlowsTool?.inputSchema.properties).toHaveProperty('query');
+      expect(searchFlowsTool?.inputSchema.properties).toHaveProperty('flowId');
+    });
+
+    it('should have exactly 13 tools defined', () => {
+      const tools = mcpServer.getToolDefinitions();
+      expect(tools.length).toBe(13);
     });
   });
 
@@ -522,6 +533,118 @@ describe('McpNodeRedServer', () => {
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed.success).toBe(false);
       expect(parsed.error).toContain('key');
+    });
+  });
+
+  describe('Tool Execution - search_flows', () => {
+    const searchFlowsFixture = [
+      {
+        id: 'tab-1',
+        type: 'tab',
+        label: 'Main Flow',
+        nodes: [
+          { id: 'n1', type: 'inject', name: 'Trigger MQTT', z: 'tab-1' },
+          { id: 'n2', type: 'mqtt out', name: 'Publish', topic: 'sensors/temp', z: 'tab-1' },
+          { id: 'n3', type: 'function', name: 'Transform', func: 'return msg;', z: 'tab-1' },
+        ],
+      },
+      {
+        id: 'tab-2',
+        type: 'tab',
+        label: 'HTTP Flow',
+        nodes: [
+          { id: 'n4', type: 'http in', name: 'API Endpoint', url: '/api/data', z: 'tab-2' },
+          { id: 'n5', type: 'http response', name: '', z: 'tab-2' },
+        ],
+      },
+    ];
+
+    beforeEach(() => {
+      mockNodeRedClient.getFlows.mockResolvedValue(searchFlowsFixture);
+    });
+
+    it('should filter nodes by type (substring, case-insensitive)', async () => {
+      const result = await mcpServer.callTool('search_flows', { type: 'mqtt' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.matches.every((m: any) => m.nodeType.toLowerCase().includes('mqtt'))).toBe(true);
+      expect(parsed.data.total).toBe(1);
+    });
+
+    it('should filter nodes by query matching name', async () => {
+      const result = await mcpServer.callTool('search_flows', { query: 'trigger' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.total).toBe(1);
+      expect(parsed.data.matches[0].nodeName).toBe('Trigger MQTT');
+    });
+
+    it('should filter nodes by query matching a string property value', async () => {
+      const result = await mcpServer.callTool('search_flows', { query: '/api/data' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.total).toBe(1);
+      expect(parsed.data.matches[0].nodeId).toBe('n4');
+    });
+
+    it('should restrict search to a specific flowId', async () => {
+      const result = await mcpServer.callTool('search_flows', { flowId: 'tab-2' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.matches.every((m: any) => m.flowId === 'tab-2')).toBe(true);
+      expect(parsed.data.total).toBe(2);
+    });
+
+    it('should AND multiple criteria together', async () => {
+      const result = await mcpServer.callTool('search_flows', { type: 'http', flowId: 'tab-2' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.success).toBe(true);
+      // Both http in and http response are in tab-2
+      expect(parsed.data.total).toBe(2);
+      expect(parsed.data.matches.every((m: any) => m.flowId === 'tab-2')).toBe(true);
+    });
+
+    it('should return error when no search parameters provided', async () => {
+      const result = await mcpServer.callTool('search_flows', {});
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain('At least one search parameter is required');
+    });
+
+    it('should include nodeId, nodeType, nodeName, flowId, flowLabel in results', async () => {
+      const result = await mcpServer.callTool('search_flows', { type: 'inject' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      const match = parsed.data.matches[0];
+      expect(match).toHaveProperty('nodeId');
+      expect(match).toHaveProperty('nodeType');
+      expect(match).toHaveProperty('nodeName');
+      expect(match).toHaveProperty('flowId');
+      expect(match).toHaveProperty('flowLabel');
+    });
+
+    it('should cap results at 10 and report full total', async () => {
+      const manyNodes = Array.from({ length: 15 }, (_, i) => ({
+        id: `fn-${i}`,
+        type: 'function',
+        name: `Func ${i}`,
+        z: 'tab-1',
+      }));
+      mockNodeRedClient.getFlows.mockResolvedValue([
+        { id: 'tab-1', type: 'tab', label: 'Big Flow', nodes: manyNodes },
+      ]);
+
+      const result = await mcpServer.callTool('search_flows', { type: 'function' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.data.matches.length).toBe(10);
+      expect(parsed.data.total).toBe(15);
     });
   });
 

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -345,18 +345,21 @@ export class McpNodeRedServer {
       },
       {
         name: 'search_flows',
-        description: 'Search for nodes in Node-RED flows by type, name, or property value. At least one parameter is required.',
+        description:
+          'Search for nodes in Node-RED flows by type, name, or property value. At least one parameter is required.',
         annotations: { readOnlyHint: true },
         inputSchema: {
           type: 'object',
           properties: {
             type: {
               type: 'string',
-              description: 'Substring match on node type (case-insensitive, e.g. "function", "mqtt")',
+              description:
+                'Substring match on node type (case-insensitive, e.g. "function", "mqtt")',
             },
             query: {
               type: 'string',
-              description: 'Substring match on node name or any string property value (case-insensitive)',
+              description:
+                'Substring match on node name or any string property value (case-insensitive)',
             },
             flowId: {
               type: 'string',

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -540,13 +540,13 @@ export class McpNodeRedServer {
           const flows = await this.nodeRedClient.getFlows();
           const typeFilterLower = typeFilter?.toLowerCase();
           const queryLower = query?.toLowerCase();
-          const matches: Array<{
+          const matches: {
             nodeId: string;
             nodeType: string;
             nodeName: string;
             flowId: string;
             flowLabel: string;
-          }> = [];
+          }[] = [];
 
           for (const flow of flows) {
             if (filterFlowId && flow.id !== filterFlowId) continue;

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -29,6 +29,9 @@ import { validateRequired, validateTypes } from '../utils/error-handling.js';
 
 import { SSEHandler } from './sse-handler.js';
 
+const SEARCH_RESULTS_LIMIT = 10;
+const SEARCH_SKIP_PROPS = new Set(['id', 'z', 'x', 'y', 'wires']);
+
 export class McpNodeRedServer {
   private server: Server;
   private nodeRedClient: NodeRedAPIClient;
@@ -340,6 +343,29 @@ export class McpNodeRedServer {
           required: ['key'],
         },
       },
+      {
+        name: 'search_flows',
+        description: 'Search for nodes in Node-RED flows by type, name, or property value. At least one parameter is required.',
+        annotations: { readOnlyHint: true },
+        inputSchema: {
+          type: 'object',
+          properties: {
+            type: {
+              type: 'string',
+              description: 'Substring match on node type (case-insensitive, e.g. "function", "mqtt")',
+            },
+            query: {
+              type: 'string',
+              description: 'Substring match on node name or any string property value (case-insensitive)',
+            },
+            flowId: {
+              type: 'string',
+              description: 'Restrict search to a specific flow ID',
+            },
+          },
+          required: [],
+        },
+      },
     ];
   }
 
@@ -499,6 +525,59 @@ export class McpNodeRedServer {
           validateRequired(args, ['key']);
           await this.nodeRedClient.deleteGlobalContext(args.key);
           result = { success: true, data: { key: args.key }, timestamp };
+          break;
+        }
+
+        case 'search_flows': {
+          const typeFilter = args?.type as string | undefined;
+          const query = args?.query as string | undefined;
+          const filterFlowId = args?.flowId as string | undefined;
+
+          if (!typeFilter && !query && !filterFlowId) {
+            throw new Error('At least one search parameter is required: type, query, or flowId');
+          }
+
+          const flows = await this.nodeRedClient.getFlows();
+          const typeFilterLower = typeFilter?.toLowerCase();
+          const queryLower = query?.toLowerCase();
+          const matches: Array<{
+            nodeId: string;
+            nodeType: string;
+            nodeName: string;
+            flowId: string;
+            flowLabel: string;
+          }> = [];
+
+          for (const flow of flows) {
+            if (filterFlowId && flow.id !== filterFlowId) continue;
+            for (const node of flow.nodes ?? []) {
+              if (typeFilterLower && !node.type.toLowerCase().includes(typeFilterLower)) continue;
+              if (queryLower) {
+                const nameMatch = (node.name ?? '').toLowerCase().includes(queryLower);
+                const propMatch = Object.entries(node).some(
+                  ([k, v]) =>
+                    !SEARCH_SKIP_PROPS.has(k) &&
+                    k !== 'name' &&
+                    typeof v === 'string' &&
+                    v.toLowerCase().includes(queryLower)
+                );
+                if (!nameMatch && !propMatch) continue;
+              }
+              matches.push({
+                nodeId: node.id,
+                nodeType: node.type,
+                nodeName: node.name ?? '',
+                flowId: flow.id,
+                flowLabel: flow.label ?? '',
+              });
+            }
+          }
+
+          result = {
+            success: true,
+            data: { matches: matches.slice(0, SEARCH_RESULTS_LIMIT), total: matches.length },
+            timestamp,
+          };
           break;
         }
 


### PR DESCRIPTION
## Summary

Adds `search_flows` MCP tool — the 13th tool in the server.

Searches Node-RED nodes in-process on the MCP side. No new Node-RED API calls beyond `getFlows()`.

**Parameters** (at least one required, all AND-ed):
- `type` — substring match on node.type (case-insensitive)
- `query` — substring match on node.name or any string property value
- `flowId` — restrict to a specific flow

**Response:** `{ matches: [{ nodeId, nodeType, nodeName, flowId, flowLabel }], total }` — hard limit of 10 results.

**Design decisions:**
- Requires at least one filter param → error otherwise (prevents token-expensive all-node dumps)
- Limit hardcoded at 10 (user requirement)
- `total` field lets the LLM know if it needs to refine the search
- `readOnlyHint: true`

## Test plan
- [ ] 9 new tests: type filter, query name match, query property match, flowId filter, AND criteria, no-params error, result shape, limit+total cap
- [ ] All 686 tests passing
- [ ] Simplify review: moved toLowerCase() calls before loops, hoisted skipProps Set to module level, named SEARCH_RESULTS_LIMIT constant