### PR TITLE
feat: add delete_flow MCP tool with dry-run safety

### DIFF
--- a/src/server/mcp-server.test.ts
+++ b/src/server/mcp-server.test.ts
@@ -46,6 +46,7 @@ const mockNodeRedClient = {
   deleteGlobalContext: vi.fn(),
   getFlowContext: vi.fn(),
   setFlowContext: vi.fn(),
+  deleteFlow: vi.fn(),
 };
 
 const mockSSEHandler = {
@@ -119,6 +120,7 @@ describe('McpNodeRedServer', () => {
     mockNodeRedClient.deleteGlobalContext.mockResolvedValue(undefined);
     mockNodeRedClient.getFlowContext.mockResolvedValue({});
     mockNodeRedClient.setFlowContext.mockResolvedValue(undefined);
+    mockNodeRedClient.deleteFlow.mockResolvedValue(undefined);
 
     mcpServer = new McpNodeRedServer();
   });
@@ -262,9 +264,9 @@ describe('McpNodeRedServer', () => {
       expect(searchFlowsTool?.inputSchema.properties).toHaveProperty('flowId');
     });
 
-    it('should have exactly 13 tools defined', () => {
+    it('should have exactly 14 tools defined', () => {
       const tools = mcpServer.getToolDefinitions();
-      expect(tools.length).toBe(13);
+      expect(tools.length).toBe(14);
     });
   });
 
@@ -647,6 +649,62 @@ describe('McpNodeRedServer', () => {
 
       expect(parsed.data.matches.length).toBe(10);
       expect(parsed.data.total).toBe(15);
+    });
+  });
+
+  describe('Tool Execution - delete_flow', () => {
+    it('should return flow info without deleting when dryRun is true (default)', async () => {
+      const result = await mcpServer.callTool('delete_flow', { flowId: 'flow-1' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(mockNodeRedClient.getFlow).toHaveBeenCalledWith('flow-1');
+      expect(mockNodeRedClient.deleteFlow).not.toHaveBeenCalled();
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.dryRun).toBe(true);
+      expect(parsed.data.wouldDelete).toEqual({ id: 'flow-1', label: 'Test Flow', nodeCount: 2 });
+    });
+
+    it('should delete flow when dryRun is false and confirm is true', async () => {
+      const result = await mcpServer.callTool('delete_flow', {
+        flowId: 'flow-1',
+        dryRun: false,
+        confirm: true,
+      });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(mockNodeRedClient.getFlow).toHaveBeenCalledWith('flow-1');
+      expect(mockNodeRedClient.deleteFlow).toHaveBeenCalledWith('flow-1');
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.deleted).toEqual({ id: 'flow-1', label: 'Test Flow', nodeCount: 2 });
+    });
+
+    it('should return error when dryRun is false but confirm is missing', async () => {
+      const result = await mcpServer.callTool('delete_flow', {
+        flowId: 'flow-1',
+        dryRun: false,
+      });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(mockNodeRedClient.deleteFlow).not.toHaveBeenCalled();
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain('confirm');
+    });
+
+    it('should return validation error when flowId is missing', async () => {
+      const result = await mcpServer.callTool('delete_flow', {});
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain('flowId');
+    });
+
+    it('should have destructiveHint annotation', () => {
+      const tools = mcpServer.getToolDefinitions();
+      const deleteFlowTool = tools.find(t => t.name === 'delete_flow');
+
+      expect(deleteFlowTool).toBeDefined();
+      expect(deleteFlowTool?.annotations?.destructiveHint).toBe(true);
+      expect(deleteFlowTool?.annotations?.readOnlyHint).toBe(false);
     });
   });
 

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -32,6 +32,14 @@ import { SSEHandler } from './sse-handler.js';
 const SEARCH_RESULTS_LIMIT = 10;
 const SEARCH_SKIP_PROPS = new Set(['id', 'z', 'x', 'y', 'wires']);
 
+interface FlowSearchMatch {
+  nodeId: string;
+  nodeType: string;
+  nodeName: string;
+  flowId: string;
+  flowLabel: string;
+}
+
 export class McpNodeRedServer {
   private server: Server;
   private nodeRedClient: NodeRedAPIClient;
@@ -344,6 +352,32 @@ export class McpNodeRedServer {
         },
       },
       {
+        name: 'delete_flow',
+        description:
+          'Delete a Node-RED flow. Default is dry-run — shows what would be deleted without acting. To delete for real: set dryRun: false AND confirm: true.',
+        annotations: { readOnlyHint: false, destructiveHint: true },
+        inputSchema: {
+          type: 'object',
+          properties: {
+            flowId: {
+              type: 'string',
+              description: 'ID of the flow to delete',
+            },
+            dryRun: {
+              type: 'boolean',
+              description: 'When true (default), returns flow details without deleting',
+              default: true,
+            },
+            confirm: {
+              type: 'boolean',
+              description:
+                'Must be true when dryRun is false — explicit confirmation of destructive action',
+            },
+          },
+          required: ['flowId'],
+        },
+      },
+      {
         name: 'search_flows',
         description:
           'Search for nodes in Node-RED flows by type, name, or property value. At least one parameter is required.',
@@ -531,6 +565,30 @@ export class McpNodeRedServer {
           break;
         }
 
+        case 'delete_flow': {
+          validateRequired(args, ['flowId']);
+          const dryRun = args?.dryRun !== false;
+          const flow = await this.nodeRedClient.getFlow(args.flowId);
+          const flowInfo = {
+            id: flow.id,
+            label: flow.label ?? '',
+            nodeCount: flow.nodes?.length ?? 0,
+          };
+
+          if (dryRun) {
+            result = { success: true, data: { dryRun: true, wouldDelete: flowInfo }, timestamp };
+            break;
+          }
+
+          if (!args?.confirm) {
+            throw new Error('Deletion requires confirm: true and dryRun: false');
+          }
+
+          await this.nodeRedClient.deleteFlow(args.flowId);
+          result = { success: true, data: { deleted: flowInfo }, timestamp };
+          break;
+        }
+
         case 'search_flows': {
           const typeFilter = args?.type as string | undefined;
           const query = args?.query as string | undefined;
@@ -543,13 +601,8 @@ export class McpNodeRedServer {
           const flows = await this.nodeRedClient.getFlows();
           const typeFilterLower = typeFilter?.toLowerCase();
           const queryLower = query?.toLowerCase();
-          const matches: {
-            nodeId: string;
-            nodeType: string;
-            nodeName: string;
-            flowId: string;
-            flowLabel: string;
-          }[] = [];
+          const matches: FlowSearchMatch[] = [];
+          let total = 0;
 
           for (const flow of flows) {
             if (filterFlowId && flow.id !== filterFlowId) continue;
@@ -566,19 +619,22 @@ export class McpNodeRedServer {
                 );
                 if (!nameMatch && !propMatch) continue;
               }
-              matches.push({
-                nodeId: node.id,
-                nodeType: node.type,
-                nodeName: node.name ?? '',
-                flowId: flow.id,
-                flowLabel: flow.label ?? '',
-              });
+              total++;
+              if (matches.length < SEARCH_RESULTS_LIMIT) {
+                matches.push({
+                  nodeId: node.id,
+                  nodeType: node.type,
+                  nodeName: node.name ?? '',
+                  flowId: flow.id,
+                  flowLabel: flow.label ?? '',
+                });
+              }
             }
           }
 
           result = {
             success: true,
-            data: { matches: matches.slice(0, SEARCH_RESULTS_LIMIT), total: matches.length },
+            data: { matches, total },
             timestamp,
           };
           break;


### PR DESCRIPTION
## Summary

- Adds `delete_flow` MCP tool (Task 3 of post-roadmap queue)
- Dry-run by default — returns flow info without deleting
- Actual deletion requires both `dryRun: false` AND `confirm: true` to prevent accidental data loss
- `destructiveHint: true` annotation for LLM awareness
- Extracts `FlowSearchMatch` interface from inline type in `search_flows`
- Caps `matches` array during collection (O(10) memory instead of O(n)) while still reporting accurate `total`

## Test plan

- [ ] 5 new tests: dry-run default, actual delete, missing confirm guard, missing flowId validation, destructiveHint annotation
- [ ] All 691 tests pass
- [ ] `yarn format` and `yarn lint` clean