### PR TITLE
feat: add validate_flow MCP tool with validate flag on create/update

### DIFF
--- a/src/server/mcp-server.test.ts
+++ b/src/server/mcp-server.test.ts
@@ -264,9 +264,18 @@ describe('McpNodeRedServer', () => {
       expect(searchFlowsTool?.inputSchema.properties).toHaveProperty('flowId');
     });
 
-    it('should have exactly 14 tools defined', () => {
+    it('should include validate_flow tool', () => {
       const tools = mcpServer.getToolDefinitions();
-      expect(tools.length).toBe(14);
+      const validateFlowTool = tools.find(t => t.name === 'validate_flow');
+
+      expect(validateFlowTool).toBeDefined();
+      expect(validateFlowTool?.annotations?.readOnlyHint).toBe(true);
+      expect(validateFlowTool?.inputSchema.required).toContain('flowId');
+    });
+
+    it('should have exactly 15 tools defined', () => {
+      const tools = mcpServer.getToolDefinitions();
+      expect(tools.length).toBe(15);
     });
   });
 
@@ -649,6 +658,139 @@ describe('McpNodeRedServer', () => {
 
       expect(parsed.data.matches.length).toBe(10);
       expect(parsed.data.total).toBe(15);
+    });
+  });
+
+  describe('Tool Execution - validate_flow', () => {
+    it('should return valid:true for a structurally correct flow', async () => {
+      const result = await mcpServer.callTool('validate_flow', { flowId: 'flow-1' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.valid).toBe(true);
+      expect(parsed.data.errors).toEqual([]);
+    });
+
+    it('should detect duplicate node IDs', async () => {
+      mockNodeRedClient.getFlow.mockResolvedValueOnce({
+        id: 'flow-dup',
+        nodes: [
+          { id: 'n1', type: 'inject' },
+          { id: 'n1', type: 'debug' },
+        ],
+      });
+
+      const result = await mcpServer.callTool('validate_flow', { flowId: 'flow-dup' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.data.valid).toBe(false);
+      expect(parsed.data.errors.some((e: string) => e.includes('Duplicate'))).toBe(true);
+    });
+
+    it('should detect missing required fields', async () => {
+      mockNodeRedClient.getFlow.mockResolvedValueOnce({
+        id: 'flow-missing',
+        nodes: [{ type: 'inject' }, { id: 'n2' }],
+      });
+
+      const result = await mcpServer.callTool('validate_flow', { flowId: 'flow-missing' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.data.valid).toBe(false);
+      expect(parsed.data.errors.some((e: string) => e.includes('"id"'))).toBe(true);
+      expect(parsed.data.errors.some((e: string) => e.includes('"type"'))).toBe(true);
+    });
+
+    it('should detect dangling wire references', async () => {
+      mockNodeRedClient.getFlow.mockResolvedValueOnce({
+        id: 'flow-wire',
+        nodes: [{ id: 'n1', type: 'inject', wires: [['n-nonexistent']] }],
+      });
+
+      const result = await mcpServer.callTool('validate_flow', { flowId: 'flow-wire' });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.data.valid).toBe(false);
+      expect(parsed.data.errors.some((e: string) => e.includes('n-nonexistent'))).toBe(true);
+    });
+
+    it('should return validation error when flowId is missing', async () => {
+      const result = await mcpServer.callTool('validate_flow', {});
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain('flowId');
+    });
+  });
+
+  describe('Tool Execution - create_flow with validate flag', () => {
+    it('should create flow without validation when validate is false', async () => {
+      const flowData = { label: 'New Flow', nodes: [] };
+      const result = await mcpServer.callTool('create_flow', { flowData, validate: false });
+
+      expect(mockNodeRedClient.createFlow).toHaveBeenCalledWith(flowData);
+      expect(result.content[0].text).toContain('Flow created');
+    });
+
+    it('should block create when validate:true and flowData has errors', async () => {
+      const flowData = {
+        nodes: [{ id: 'n1', type: 'inject', wires: [['n-ghost']] }],
+      };
+      const result = await mcpServer.callTool('create_flow', { flowData, validate: true });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(mockNodeRedClient.createFlow).not.toHaveBeenCalled();
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain('Validation failed');
+    });
+
+    it('should create flow when validate:true and flowData is valid', async () => {
+      const flowData = {
+        label: 'Good Flow',
+        nodes: [
+          { id: 'n1', type: 'inject', wires: [['n2']] },
+          { id: 'n2', type: 'debug', wires: [] },
+        ],
+      };
+      const result = await mcpServer.callTool('create_flow', { flowData, validate: true });
+
+      expect(mockNodeRedClient.createFlow).toHaveBeenCalledWith(flowData);
+      expect(result.content[0].text).toContain('Flow created');
+    });
+  });
+
+  describe('Tool Execution - update_flow with validate flag', () => {
+    it('should block update when validate:true and flowData has duplicate IDs', async () => {
+      const flowData = {
+        nodes: [
+          { id: 'dup', type: 'inject' },
+          { id: 'dup', type: 'debug' },
+        ],
+      };
+      const result = await mcpServer.callTool('update_flow', {
+        flowId: 'flow-1',
+        flowData,
+        validate: true,
+      });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(mockNodeRedClient.updateFlow).not.toHaveBeenCalled();
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain('Validation failed');
+    });
+
+    it('should update flow when validate:true and flowData is valid', async () => {
+      const flowData = {
+        nodes: [{ id: 'n1', type: 'inject' }],
+      };
+      const result = await mcpServer.callTool('update_flow', {
+        flowId: 'flow-1',
+        flowData,
+        validate: true,
+      });
+
+      expect(mockNodeRedClient.updateFlow).toHaveBeenCalledWith('flow-1', flowData);
+      expect(result.content[0].text).toContain('updated successfully');
     });
   });
 

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -50,8 +50,7 @@ function validateFlowData(flow: { nodes?: unknown[] }): FlowValidationResult {
   const nodes = Array.isArray(flow?.nodes) ? (flow.nodes as Record<string, unknown>[]) : [];
   const nodeIds = new Set<string>();
 
-  for (let i = 0; i < nodes.length; i++) {
-    const node = nodes[i];
+  for (const [i, node] of nodes.entries()) {
     const id = typeof node.id === 'string' ? node.id : '';
     const label = id ? `Node "${id}"` : `Node[${i}]`;
 
@@ -67,8 +66,7 @@ function validateFlowData(flow: { nodes?: unknown[] }): FlowValidationResult {
     }
   }
 
-  for (let i = 0; i < nodes.length; i++) {
-    const node = nodes[i];
+  for (const [i, node] of nodes.entries()) {
     const id = typeof node.id === 'string' ? node.id : '';
     const label = id ? `Node "${id}"` : `Node[${i}]`;
     if (!Array.isArray(node.wires)) continue;

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -40,6 +40,65 @@ interface FlowSearchMatch {
   flowLabel: string;
 }
 
+interface FlowValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+function validateFlowData(flow: { nodes?: unknown[] }): FlowValidationResult {
+  const errors: string[] = [];
+  const nodes = Array.isArray(flow?.nodes) ? (flow.nodes as Record<string, unknown>[]) : [];
+  const nodeIds = new Set<string>();
+
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    const id = typeof node.id === 'string' ? node.id : '';
+    const label = id ? `Node "${id}"` : `Node[${i}]`;
+
+    if (!id) errors.push(`${label}: missing required field "id"`);
+    if (!node.type) errors.push(`${label}: missing required field "type"`);
+
+    if (id) {
+      if (nodeIds.has(id)) {
+        errors.push(`Duplicate node ID: "${id}"`);
+      } else {
+        nodeIds.add(id);
+      }
+    }
+  }
+
+  for (let i = 0; i < nodes.length; i++) {
+    const node = nodes[i];
+    const id = typeof node.id === 'string' ? node.id : '';
+    const label = id ? `Node "${id}"` : `Node[${i}]`;
+    if (!Array.isArray(node.wires)) continue;
+    for (const group of node.wires as unknown[]) {
+      if (!Array.isArray(group)) {
+        errors.push(`${label}: wires must be an array of arrays`);
+        continue;
+      }
+      for (const target of group as unknown[]) {
+        if (typeof target !== 'string') {
+          errors.push(`${label}: wire target must be a string`);
+          continue;
+        }
+        if (!nodeIds.has(target)) {
+          errors.push(`${label}: wire references unknown node "${target}"`);
+        }
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+function validateFlowOrThrow(flowData: { nodes?: unknown[] }): void {
+  const validation = validateFlowData(flowData);
+  if (!validation.valid) {
+    throw new Error(`Validation failed:\n${validation.errors.map(e => `- ${e}`).join('\n')}`);
+  }
+}
+
 export class McpNodeRedServer {
   private server: Server;
   private nodeRedClient: NodeRedAPIClient;
@@ -170,6 +229,19 @@ export class McpNodeRedServer {
         },
       },
       {
+        name: 'validate_flow',
+        description:
+          'Validate a Node-RED flow for structural errors: missing required node fields, duplicate node IDs, and wire references to non-existent nodes.',
+        annotations: { readOnlyHint: true },
+        inputSchema: {
+          type: 'object',
+          properties: {
+            flowId: { type: 'string', description: 'ID of the flow to fetch and validate' },
+          },
+          required: ['flowId'],
+        },
+      },
+      {
         name: 'create_flow',
         description: 'Create a new Node-RED flow',
         annotations: { readOnlyHint: false },
@@ -185,6 +257,11 @@ export class McpNodeRedServer {
                 disabled: { type: 'boolean' },
               },
             },
+            validate: {
+              type: 'boolean',
+              description: 'If true, validate flowData for structural errors before creating',
+              default: false,
+            },
           },
           required: ['flowData'],
         },
@@ -198,6 +275,11 @@ export class McpNodeRedServer {
           properties: {
             flowId: { type: 'string', description: 'Flow ID to update' },
             flowData: { type: 'object', description: 'Updated flow data' },
+            validate: {
+              type: 'boolean',
+              description: 'If true, validate flowData for structural errors before updating',
+              default: false,
+            },
           },
           required: ['flowId', 'flowData'],
         },
@@ -439,8 +521,16 @@ export class McpNodeRedServer {
           };
           break;
 
+        case 'validate_flow': {
+          validateRequired(args, ['flowId']);
+          const flow = await this.nodeRedClient.getFlow(args.flowId);
+          result = { success: true, data: validateFlowData(flow), timestamp };
+          break;
+        }
+
         case 'create_flow':
           validateRequired(args, ['flowData']);
+          if (args?.validate) validateFlowOrThrow(args.flowData);
           const createdFlow = await this.nodeRedClient.createFlow(args.flowData);
           return {
             content: [
@@ -453,6 +543,7 @@ export class McpNodeRedServer {
 
         case 'update_flow':
           validateRequired(args, ['flowId', 'flowData']);
+          if (args?.validate) validateFlowOrThrow(args.flowData);
           await this.nodeRedClient.updateFlow(args.flowId, args.flowData);
           return {
             content: [


### PR DESCRIPTION
## Summary

- Adds `validate_flow` MCP tool (Task 1 of post-roadmap queue)
- Structural validation: missing required fields (`id`, `type`), duplicate node IDs, dangling wire references
- Adds optional `validate: boolean` flag to `create_flow` and `update_flow` — blocks the API call and returns errors if flow data is invalid
- Extracted `validateFlowOrThrow()` helper to avoid duplication between create/update paths

## Test plan

- [ ] 5 validate_flow tests: valid flow, duplicate IDs, missing fields, dangling wires, missing flowId
- [ ] 3 create_flow+validate tests: blocked on error, passes on valid, no-op when validate false
- [ ] 2 update_flow+validate tests: blocked on error, passes on valid
- [ ] All 702 tests pass