### PR TITLE
feat(prompts): MCP Prompts Library (Feature 1)

### DIFF
--- a/src/prompts/audit-security.ts
+++ b/src/prompts/audit-security.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 
-import type { PromptDefinition } from './types.js';
-import { userMessage } from './types.js';
+import { userMessage, type PromptDefinition } from './types.js';
 
 const argsSchema = z.object({
   flowId: z.string().min(1).optional(),

--- a/src/prompts/audit-security.ts
+++ b/src/prompts/audit-security.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+
+import type { PromptDefinition } from './types.js';
+import { userMessage } from './types.js';
+
+const argsSchema = z.object({
+  flowId: z.string().min(1).optional(),
+  severity: z.enum(['all', 'high']).default('all'),
+});
+
+export const auditSecurityPrompt: PromptDefinition<typeof argsSchema> = {
+  name: 'audit_security',
+  description:
+    'Perform a basic security audit: exposed credentials, unauthenticated HTTP endpoints, unsafe eval in function nodes, sensitive global context.',
+  arguments: [
+    {
+      name: 'flowId',
+      description: 'Limit the audit to a specific flow (omit to audit all flows)',
+      required: false,
+    },
+    {
+      name: 'severity',
+      description: 'Reporting threshold: "all" (default) or "high" only',
+      required: false,
+    },
+  ],
+  argsSchema,
+  render: ({ flowId, severity }) => {
+    const scopePhrase = flowId ? ` in flow "${flowId}"` : ' across all flows';
+    const flowFilterArg = flowId ? `, flowId="${flowId}"` : '';
+    const severityFilterLine =
+      severity === 'high'
+        ? 'Filter: report only HIGH-severity findings; suppress medium and low.'
+        : 'Filter: report all findings (high, medium, low).';
+
+    const text = [
+      `Audit Node-RED for security issues${scopePhrase}.`,
+      '',
+      'Checks:',
+      '1. **Credentials in plaintext** — search for nodes with `username`, `password`, `apikey`, `token` properties not using the `credentials` storage.',
+      `   Use: \`search_flows(query="password"${flowFilterArg})\`, \`search_flows(query="apikey"${flowFilterArg})\`, \`search_flows(query="token"${flowFilterArg})\`.`,
+      '',
+      '2. **Unauthenticated HTTP endpoints** — find `http in` nodes; check the flow path for an auth middleware.',
+      `   Use: \`search_flows(type="http in"${flowFilterArg})\`.`,
+      '',
+      '3. **eval / new Function in function nodes** — unsafe dynamic code.',
+      `   Use: \`search_flows(type="function"${flowFilterArg})\`, then fetch each and check for \`eval(\`, \`new Function(\`, \`require(\`.`,
+      '',
+      '4. **Exposed global context** — sensitive keys in global context.',
+      '   Use: `get_context(scope="global")`.',
+      '',
+      'Report each finding as: severity (high/medium/low) → location → evidence → fix.',
+      severityFilterLine,
+    ].join('\n');
+
+    return {
+      description: flowId
+        ? `Security audit for flow ${flowId} (severity: ${severity})`
+        : `Security audit across all flows (severity: ${severity})`,
+      messages: [userMessage(text)],
+    };
+  },
+};

--- a/src/prompts/debug-flow.ts
+++ b/src/prompts/debug-flow.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+
+import type { PromptDefinition } from './types.js';
+import { userMessage } from './types.js';
+
+const argsSchema = z.object({
+  flowId: z.string().min(1, 'flowId is required'),
+  symptom: z.string().optional(),
+});
+
+export const debugFlowPrompt: PromptDefinition<typeof argsSchema> = {
+  name: 'debug_flow',
+  description:
+    'Walks the agent through diagnosing a Node-RED flow: fetch, validate, check state, search nodes, then report root cause.',
+  arguments: [
+    { name: 'flowId', description: 'ID of the flow to debug', required: true },
+    {
+      name: 'symptom',
+      description: 'Free-text description of the observed problem (optional)',
+      required: false,
+    },
+  ],
+  argsSchema,
+  render: ({ flowId, symptom }) => {
+    const symptomLine = symptom && symptom.trim().length > 0 ? symptom : 'none';
+    const text = [
+      'You are debugging a Node-RED flow.',
+      '',
+      'Steps to follow:',
+      `1. Call \`get_flow(flowId="${flowId}")\` to fetch the full flow definition.`,
+      `2. Call \`validate_flow(flowId="${flowId}")\` to find structural errors.`,
+      '3. Call `get_flow_state()` to confirm the flow is running.',
+      `4. If the symptom mentions a specific node, use \`search_flows(flowId="${flowId}", query="<node-ref>")\`.`,
+      `5. Cross-reference with \`get_context(scope="flow", flowId="${flowId}")\` if state-dependent.`,
+      '',
+      `User-reported symptom: ${symptomLine}`,
+      '',
+      'Report findings as: root cause → evidence → suggested fix.',
+    ].join('\n');
+
+    return {
+      description: `Debug Node-RED flow ${flowId}`,
+      messages: [userMessage(text)],
+    };
+  },
+};

--- a/src/prompts/debug-flow.ts
+++ b/src/prompts/debug-flow.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 
-import type { PromptDefinition } from './types.js';
-import { userMessage } from './types.js';
+import { userMessage, type PromptDefinition } from './types.js';
 
 const argsSchema = z.object({
   flowId: z.string().min(1, 'flowId is required'),
@@ -22,7 +21,7 @@ export const debugFlowPrompt: PromptDefinition<typeof argsSchema> = {
   ],
   argsSchema,
   render: ({ flowId, symptom }) => {
-    const symptomLine = symptom && symptom.trim().length > 0 ? symptom : 'none';
+    const symptomLine = symptom?.trim() || 'none';
     const text = [
       'You are debugging a Node-RED flow.',
       '',

--- a/src/prompts/document-flow.ts
+++ b/src/prompts/document-flow.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 
-import type { PromptDefinition } from './types.js';
-import { userMessage } from './types.js';
+import { userMessage, type PromptDefinition } from './types.js';
 
 const argsSchema = z.object({
   flowId: z.string().min(1, 'flowId is required'),

--- a/src/prompts/document-flow.ts
+++ b/src/prompts/document-flow.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+
+import type { PromptDefinition } from './types.js';
+import { userMessage } from './types.js';
+
+const argsSchema = z.object({
+  flowId: z.string().min(1, 'flowId is required'),
+  includeDiagram: z.boolean().default(true),
+});
+
+export const documentFlowPrompt: PromptDefinition<typeof argsSchema> = {
+  name: 'document_flow',
+  description:
+    'Generate a complete Markdown document for a Node-RED flow: overview, trigger, data flow (with optional Mermaid diagram), nodes table, dependencies, configuration.',
+  arguments: [
+    { name: 'flowId', description: 'ID of the flow to document', required: true },
+    {
+      name: 'includeDiagram',
+      description: 'Include a Mermaid diagram of node connections (default: true)',
+      required: false,
+    },
+  ],
+  argsSchema,
+  render: ({ flowId, includeDiagram }) => {
+    const diagramLine = includeDiagram
+      ? '<Mermaid `graph TD` of node connections, one edge per wire.>'
+      : '<Plain-text description of the data flow path through the nodes.>';
+
+    const text = [
+      `Generate complete documentation for Node-RED flow "${flowId}".`,
+      '',
+      'Steps:',
+      `1. \`get_flow(flowId="${flowId}")\` — fetch nodes + wires.`,
+      '2. Identify: trigger → processors → outputs → side effects.',
+      '3. Build sections:',
+      '',
+      '## Overview',
+      'One paragraph: purpose, trigger, output.',
+      '',
+      '## Trigger',
+      'Trigger node(s) details (type, schedule/topic/path).',
+      '',
+      '## Data Flow',
+      diagramLine,
+      '',
+      '## Nodes',
+      'Table: id | type | name | purpose.',
+      '',
+      '## Dependencies',
+      'External: MQTT topics, HTTP endpoints, HA entities, npm packages.',
+      '',
+      '## Configuration',
+      'Required env vars, credentials, context variables.',
+      '',
+      'Output as a single Markdown document, ready to paste into a wiki.',
+    ].join('\n');
+
+    return {
+      description: `Documentation for Node-RED flow ${flowId}`,
+      messages: [userMessage(text)],
+    };
+  },
+};

--- a/src/prompts/explain-automation.ts
+++ b/src/prompts/explain-automation.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 
-import type { PromptDefinition } from './types.js';
-import { userMessage } from './types.js';
+import { userMessage, type PromptDefinition } from './types.js';
 
 const argsSchema = z.object({
   flowId: z.string().min(1, 'flowId is required'),

--- a/src/prompts/explain-automation.ts
+++ b/src/prompts/explain-automation.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+import type { PromptDefinition } from './types.js';
+import { userMessage } from './types.js';
+
+const argsSchema = z.object({
+  flowId: z.string().min(1, 'flowId is required'),
+  audience: z.enum(['developer', 'end-user']).default('developer'),
+});
+
+export const explainAutomationPrompt: PromptDefinition<typeof argsSchema> = {
+  name: 'explain_automation',
+  description:
+    'Explain a Node-RED flow in plain language for the given audience: what triggers it, what it does, where data ends up.',
+  arguments: [
+    { name: 'flowId', description: 'ID of the flow to explain', required: true },
+    {
+      name: 'audience',
+      description: 'Target audience: "developer" (default) or "end-user"',
+      required: false,
+    },
+  ],
+  argsSchema,
+  render: ({ flowId, audience }) => {
+    const audienceNote =
+      audience === 'end-user'
+        ? 'For "end-user" audience: skip implementation details, focus on outcomes and user impact.'
+        : 'For "developer" audience: include node-level detail and side effects.';
+
+    const text = [
+      `Explain Node-RED flow "${flowId}" to a ${audience}.`,
+      '',
+      'Steps:',
+      `1. Fetch the flow: \`get_flow(flowId="${flowId}")\`.`,
+      '2. Identify the trigger nodes (inject, mqtt-in, http-in, schedule).',
+      '3. Trace the data path through processing nodes.',
+      '4. List all side effects (outbound MQTT, HTTP, function nodes with global writes).',
+      '',
+      'Format:',
+      '- **What triggers it:** ...',
+      '- **What it does:** (one-paragraph plain-language summary)',
+      '- **Where the data ends up:** ...',
+      '- **Key nodes:** [list with one-line role each]',
+      '',
+      "Use Hebrew if the flow's label/comments are in Hebrew, otherwise English.",
+      audienceNote,
+    ].join('\n');
+
+    return {
+      description: `Explain Node-RED flow ${flowId} (${audience})`,
+      messages: [userMessage(text)],
+    };
+  },
+};

--- a/src/prompts/index.ts
+++ b/src/prompts/index.ts
@@ -1,0 +1,54 @@
+/**
+ * Prompts registry — central list/get for all MCP prompts.
+ */
+import { auditSecurityPrompt } from './audit-security.js';
+import { debugFlowPrompt } from './debug-flow.js';
+import { documentFlowPrompt } from './document-flow.js';
+import { explainAutomationPrompt } from './explain-automation.js';
+import type { PromptDefinition, RenderedPrompt, PromptArgument } from './types.js';
+import { PromptNotFoundError } from './types.js';
+
+export interface ListedPrompt {
+  name: string;
+  description: string;
+  arguments: PromptArgument[];
+}
+
+class PromptRegistry {
+  private readonly prompts: Map<string, PromptDefinition>;
+
+  constructor(prompts: PromptDefinition[]) {
+    this.prompts = new Map(prompts.map(p => [p.name, p]));
+  }
+
+  list(): ListedPrompt[] {
+    return Array.from(this.prompts.values()).map(p => ({
+      name: p.name,
+      description: p.description,
+      arguments: p.arguments,
+    }));
+  }
+
+  async get(name: string, args: unknown): Promise<RenderedPrompt> {
+    const prompt = this.prompts.get(name);
+    if (!prompt) {
+      throw new PromptNotFoundError(name);
+    }
+    const parsed = prompt.argsSchema.parse(args ?? {});
+    return await prompt.render(parsed);
+  }
+
+  has(name: string): boolean {
+    return this.prompts.has(name);
+  }
+}
+
+export const promptRegistry = new PromptRegistry([
+  debugFlowPrompt,
+  explainAutomationPrompt,
+  auditSecurityPrompt,
+  documentFlowPrompt,
+]);
+
+export { PromptNotFoundError } from './types.js';
+export type { PromptDefinition, RenderedPrompt, PromptArgument } from './types.js';

--- a/src/prompts/types.ts
+++ b/src/prompts/types.ts
@@ -1,0 +1,39 @@
+/**
+ * Prompts library types — modular MCP prompts with Zod-validated arguments.
+ */
+import type { ZodTypeAny, z } from 'zod';
+
+export interface PromptArgument {
+  name: string;
+  description: string;
+  required?: boolean;
+}
+
+export interface RenderedPromptMessage {
+  role: 'user' | 'assistant';
+  content: { type: 'text'; text: string };
+}
+
+export interface RenderedPrompt {
+  description: string;
+  messages: RenderedPromptMessage[];
+}
+
+export interface PromptDefinition<S extends ZodTypeAny = ZodTypeAny> {
+  name: string;
+  description: string;
+  arguments: PromptArgument[];
+  argsSchema: S;
+  render: (args: z.infer<S>) => RenderedPrompt | Promise<RenderedPrompt>;
+}
+
+export class PromptNotFoundError extends Error {
+  constructor(name: string) {
+    super(`Prompt not found: ${name}`);
+    this.name = 'PromptNotFoundError';
+  }
+}
+
+export function userMessage(text: string): RenderedPromptMessage {
+  return { role: 'user', content: { type: 'text', text } };
+}

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -12,6 +12,7 @@ import {
   GetPromptRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 
+import { promptRegistry } from '../prompts/index.js';
 import { NodeRedAPIClient } from '../services/nodered-api.js';
 import {
   McpServerConfig,
@@ -882,53 +883,17 @@ export class McpNodeRedServer {
   }
 
   /**
-   * Get prompt definitions
+   * Get prompt definitions (delegates to prompt registry)
    */
   private getPromptDefinitions() {
-    return [
-      {
-        name: 'create_simple_flow',
-        description: 'Create a simple Node-RED flow with common patterns',
-      },
-      {
-        name: 'debug_flow_issues',
-        description: 'Help debug common Node-RED flow issues',
-      },
-      {
-        name: 'optimize_flow_performance',
-        description: 'Suggestions for optimizing Node-RED flow performance',
-      },
-      {
-        name: 'flow_documentation',
-        description: 'Generate documentation for a Node-RED flow',
-      },
-    ];
+    return promptRegistry.list();
   }
 
   /**
-   * Get specific prompt
+   * Get specific prompt (delegates to prompt registry)
    */
   private async getPrompt(name: string, args: any) {
-    // This would contain prompt templates for common Node-RED tasks
-    const prompts = {
-      create_simple_flow: `Create a simple Node-RED flow that demonstrates best practices...`,
-      debug_flow_issues: `Help debug this Node-RED flow by analyzing common issues...`,
-      optimize_flow_performance: `Analyze this Node-RED flow for performance optimizations...`,
-      flow_documentation: `Generate comprehensive documentation for this Node-RED flow...`,
-    };
-
-    return {
-      description: `Node-RED ${name} prompt`,
-      messages: [
-        {
-          role: 'user',
-          content: {
-            type: 'text',
-            text: prompts[name as keyof typeof prompts] || 'Prompt not found',
-          },
-        },
-      ],
-    };
+    return await promptRegistry.get(name, args);
   }
 
   /**

--- a/tests/unit/prompts/audit-security.spec.ts
+++ b/tests/unit/prompts/audit-security.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+
+import { auditSecurityPrompt } from '../../../src/prompts/audit-security.js';
+
+function text(rendered: { messages: { content: { text: string } }[] }) {
+  return rendered.messages[0].content.text;
+}
+
+describe('audit_security prompt', () => {
+  it('without flowId reports "across all flows"', () => {
+    const args = auditSecurityPrompt.argsSchema.parse({});
+    const out = auditSecurityPrompt.render(args);
+    expect(text(out)).toContain('across all flows');
+  });
+
+  it('with flowId narrows scope to that flow', () => {
+    const args = auditSecurityPrompt.argsSchema.parse({ flowId: 'flow-X' });
+    const out = auditSecurityPrompt.render(args);
+    expect(text(out)).toContain('in flow "flow-X"');
+    expect(text(out)).toContain('flowId="flow-X"');
+  });
+
+  it('severity="high" filter line appears', () => {
+    const out = auditSecurityPrompt.render({ severity: 'high' });
+    expect(text(out)).toContain('report only HIGH-severity findings');
+  });
+
+  it('default severity is "all"', () => {
+    const args = auditSecurityPrompt.argsSchema.parse({});
+    expect(args.severity).toBe('all');
+    const out = auditSecurityPrompt.render(args);
+    expect(text(out)).toContain('report all findings');
+  });
+});

--- a/tests/unit/prompts/debug-flow.spec.ts
+++ b/tests/unit/prompts/debug-flow.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { ZodError } from 'zod';
+
+import { debugFlowPrompt } from '../../../src/prompts/debug-flow.js';
+
+function text(rendered: { messages: { content: { text: string } }[] }) {
+  return rendered.messages[0].content.text;
+}
+
+describe('debug_flow prompt', () => {
+  it('renders with only flowId and reports symptom as "none"', () => {
+    const out = debugFlowPrompt.render({ flowId: 'abc' });
+    expect(text(out)).toContain('"abc"');
+    expect(text(out)).toContain('User-reported symptom: none');
+  });
+
+  it('includes the provided symptom verbatim', () => {
+    const out = debugFlowPrompt.render({
+      flowId: 'flow-42',
+      symptom: 'no messages on mqtt out',
+    });
+    expect(text(out)).toContain('User-reported symptom: no messages on mqtt out');
+  });
+
+  it('rejects an empty flowId via Zod', () => {
+    expect(() => debugFlowPrompt.argsSchema.parse({ flowId: '' })).toThrow(ZodError);
+  });
+
+  it('declares flowId as required and symptom as optional', () => {
+    const argMap = Object.fromEntries(debugFlowPrompt.arguments.map(a => [a.name, a]));
+    expect(argMap.flowId.required).toBe(true);
+    expect(argMap.symptom.required).toBe(false);
+  });
+});

--- a/tests/unit/prompts/document-flow.spec.ts
+++ b/tests/unit/prompts/document-flow.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { ZodError } from 'zod';
+
+import { documentFlowPrompt } from '../../../src/prompts/document-flow.js';
+
+function text(rendered: { messages: { content: { text: string } }[] }) {
+  return rendered.messages[0].content.text;
+}
+
+describe('document_flow prompt', () => {
+  it('includes Mermaid by default', () => {
+    const args = documentFlowPrompt.argsSchema.parse({ flowId: 'f1' });
+    expect(args.includeDiagram).toBe(true);
+    const out = documentFlowPrompt.render(args);
+    expect(text(out)).toContain('Mermaid');
+  });
+
+  it('omits Mermaid when includeDiagram is false', () => {
+    const out = documentFlowPrompt.render({ flowId: 'f1', includeDiagram: false });
+    expect(text(out)).not.toContain('Mermaid');
+    expect(text(out)).toContain('Plain-text description');
+  });
+
+  it('requires flowId', () => {
+    expect(() => documentFlowPrompt.argsSchema.parse({})).toThrow(ZodError);
+  });
+});

--- a/tests/unit/prompts/explain-automation.spec.ts
+++ b/tests/unit/prompts/explain-automation.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { ZodError } from 'zod';
+
+import { explainAutomationPrompt } from '../../../src/prompts/explain-automation.js';
+
+function text(rendered: { messages: { content: { text: string } }[] }) {
+  return rendered.messages[0].content.text;
+}
+
+describe('explain_automation prompt', () => {
+  it('defaults audience to "developer"', () => {
+    const args = explainAutomationPrompt.argsSchema.parse({ flowId: 'flow-1' });
+    expect(args.audience).toBe('developer');
+    const out = explainAutomationPrompt.render(args);
+    expect(text(out)).toContain('to a developer');
+  });
+
+  it('end-user audience changes the output instructions', () => {
+    const out = explainAutomationPrompt.render({ flowId: 'flow-1', audience: 'end-user' });
+    expect(text(out)).toContain('to a end-user');
+    expect(text(out)).toContain('skip implementation details');
+  });
+
+  it('rejects invalid audience', () => {
+    expect(() =>
+      explainAutomationPrompt.argsSchema.parse({ flowId: 'x', audience: 'wrong' })
+    ).toThrow(ZodError);
+  });
+});

--- a/tests/unit/prompts/registry.spec.ts
+++ b/tests/unit/prompts/registry.spec.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { ZodError } from 'zod';
+
+import { promptRegistry, PromptNotFoundError } from '../../../src/prompts/index.js';
+
+describe('promptRegistry', () => {
+  it('lists all four prompts', () => {
+    const names = promptRegistry.list().map(p => p.name);
+    expect(names.sort()).toEqual([
+      'audit_security',
+      'debug_flow',
+      'document_flow',
+      'explain_automation',
+    ]);
+  });
+
+  it('returns MCP-shaped prompt entries (name, description, arguments)', () => {
+    for (const entry of promptRegistry.list()) {
+      expect(entry).toHaveProperty('name');
+      expect(entry).toHaveProperty('description');
+      expect(Array.isArray(entry.arguments)).toBe(true);
+      for (const arg of entry.arguments) {
+        expect(arg).toHaveProperty('name');
+        expect(arg).toHaveProperty('description');
+      }
+    }
+  });
+
+  it('throws PromptNotFoundError for unknown name', async () => {
+    await expect(promptRegistry.get('not_a_prompt', {})).rejects.toBeInstanceOf(
+      PromptNotFoundError
+    );
+  });
+
+  it('throws ZodError when required args are missing', async () => {
+    await expect(promptRegistry.get('debug_flow', {})).rejects.toBeInstanceOf(ZodError);
+  });
+
+  it('has() returns true for known prompts and false otherwise', () => {
+    expect(promptRegistry.has('debug_flow')).toBe(true);
+    expect(promptRegistry.has('totally_made_up')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Feature 1 — MCP Prompts Library

Implements MCP Prompts (per spec [dXvl3Cl95cnY](https://review.danielshaprvt.work/r/dXvl3Cl95cnY)).

### Scope

Replaces the legacy 4 hardcoded prompt stubs with a typed, Zod-validated registry of 4 production-ready prompt templates:

| Name | Purpose | Required args |
|---|---|---|
| `debug_flow` | Step-by-step debugging walkthrough for a misbehaving flow | `flowId`, optional `symptom` |
| `explain_automation` | Plain-language explanation of a flow's behavior | `flowId`, optional `audience` (`developer` \| `end-user`, default `developer`) |
| `audit_security` | Security review (credentials, http endpoints, eval, global ctx) | optional `flowId`, optional `severity` (`all` \| `high`, default `all`) |
| `document_flow` | Markdown documentation generator for a flow | `flowId`, optional `includeDiagram` (default `true`) |

### Architecture

- `src/prompts/types.ts` — `PromptDefinition<S>` interface + `PromptNotFoundError` + helpers
- `src/prompts/<name>.ts` — one file per prompt, each exporting a typed definition
- `src/prompts/index.ts` — `PromptRegistry` (list / get / has) + singleton `promptRegistry`
- `src/server/mcp-server.ts` — `getPromptDefinitions()` and `getPrompt()` delegate to the registry

Each prompt validates its arguments with a Zod 4 schema before rendering. Invalid input throws `ZodError`; unknown prompt name throws `PromptNotFoundError`. Both propagate to the MCP SDK as proper JSON-RPC errors.

### Tests

Five vitest spec files under `tests/unit/prompts/`:

- `registry.spec.ts` — list shape, error paths
- `debug-flow.spec.ts` — default vs. provided symptom, required `flowId`
- `explain-automation.spec.ts` — audience default + variant + invalid enum
- `audit-security.spec.ts` — scope variants + severity filter
- `document-flow.spec.ts` — Mermaid toggle + required `flowId`

### Workflow

- Spec approved on Review Hub (ID `dXvl3Cl95cnY`, all 12 sections green, zero annotations)
- Per the serial feature law: this is Feature 1 of 5; no other features touched
- `simplify` skill will run on this PR before merge

### Manual verification (post-merge)

After merge + CI deploys to `mcp-nodered.danielshaprvt.work`, an MCP `listPrompts` call should return the 4 new names and `getPrompt(name, args)` should return rendered messages.