### PR TITLE
fix: green CI for Feature 1 — prompts/get return shape + test names

### DIFF
--- a/src/server/mcp-server.test.ts
+++ b/src/server/mcp-server.test.ts
@@ -1033,55 +1033,53 @@ describe('McpNodeRedServer', () => {
       expect(result.prompts.length).toBeGreaterThan(0);
     });
 
-    it('should include create_simple_flow prompt', async () => {
+    it('should include debug_flow prompt', async () => {
       const result = await mcpServer.listPrompts();
 
-      const prompt = result.prompts.find((p: any) => p.name === 'create_simple_flow');
+      const prompt = result.prompts.find((p: any) => p.name === 'debug_flow');
       expect(prompt).toBeDefined();
       expect(prompt?.description).toBeDefined();
     });
 
-    it('should include debug_flow_issues prompt', async () => {
+    it('should include explain_automation prompt', async () => {
       const result = await mcpServer.listPrompts();
 
-      const prompt = result.prompts.find((p: any) => p.name === 'debug_flow_issues');
+      const prompt = result.prompts.find((p: any) => p.name === 'explain_automation');
       expect(prompt).toBeDefined();
     });
 
-    it('should include optimize_flow_performance prompt', async () => {
+    it('should include audit_security prompt', async () => {
       const result = await mcpServer.listPrompts();
 
-      const prompt = result.prompts.find((p: any) => p.name === 'optimize_flow_performance');
+      const prompt = result.prompts.find((p: any) => p.name === 'audit_security');
       expect(prompt).toBeDefined();
     });
 
-    it('should include flow_documentation prompt', async () => {
+    it('should include document_flow prompt', async () => {
       const result = await mcpServer.listPrompts();
 
-      const prompt = result.prompts.find((p: any) => p.name === 'flow_documentation');
+      const prompt = result.prompts.find((p: any) => p.name === 'document_flow');
       expect(prompt).toBeDefined();
     });
   });
 
   describe('Prompt Retrieval', () => {
-    it('should get create_simple_flow prompt', async () => {
-      const result = await mcpServer.getPromptPublic('create_simple_flow', {});
+    it('should get debug_flow prompt', async () => {
+      const result = await mcpServer.getPromptPublic('debug_flow', { flowId: 'flow-1' });
 
       expect(result.description).toBeDefined();
       expect(result.messages).toBeDefined();
       expect(result.messages[0]?.role).toBe('user');
     });
 
-    it('should get debug_flow_issues prompt', async () => {
-      const result = await mcpServer.getPromptPublic('debug_flow_issues', {});
+    it('should get explain_automation prompt', async () => {
+      const result = await mcpServer.getPromptPublic('explain_automation', { flowId: 'flow-1' });
 
       expect((result.messages[0]?.content as any)?.type).toBe('text');
     });
 
-    it('should handle unknown prompt', async () => {
-      const result = await mcpServer.getPromptPublic('unknown_prompt', {});
-
-      expect((result.messages[0]?.content as any)?.text).toContain('not found');
+    it('should throw PromptNotFoundError for unknown prompt', async () => {
+      await expect(mcpServer.getPromptPublic('unknown_prompt', {})).rejects.toThrow(/not found/);
     });
   });
 
@@ -1147,7 +1145,7 @@ describe('McpNodeRedServer', () => {
     });
 
     it('should expose getPromptPublic method', async () => {
-      const result = await mcpServer.getPromptPublic('create_simple_flow', {});
+      const result = await mcpServer.getPromptPublic('debug_flow', { flowId: 'flow-1' });
 
       expect(result.description).toBeDefined();
       expect(result.messages).toBeDefined();

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -180,7 +180,8 @@ export class McpNodeRedServer {
 
     this.server.setRequestHandler(GetPromptRequestSchema, async request => {
       const { name, arguments: args } = request.params;
-      return await this.getPrompt(name, args || {});
+      const rendered = await this.getPrompt(name, args || {});
+      return { description: rendered.description, messages: rendered.messages };
     });
   }
 


### PR DESCRIPTION
## Why

PR #92 (Feature 1 — MCP Prompts Library) merged with a red CI:
- **Quality** failed: `src/server/mcp-server.ts(181,59)` — TS2345 because the `prompts/get` handler returned `RenderedPrompt` directly while the SDK's `GetPromptRequestSchema` handler expects `{ description, messages }`.
- **Tests (Node 22 + 23)** failed: 8 specs in `src/server/mcp-server.test.ts` still referenced the legacy prompt names that Feature 1 replaced (`create_simple_flow`, `debug_flow_issues`, `optimize_flow_performance`, `flow_documentation`).

Deploy was skipped, so Feature 1 never reached production.

## What

- `src/server/mcp-server.ts` — handler now returns `{ description: rendered.description, messages: rendered.messages }`, matching the SDK return-type union.
- `src/server/mcp-server.test.ts` — tests updated to the four current prompt names (`debug_flow`, `explain_automation`, `audit_security`, `document_flow`) and to expect `PromptNotFoundError` (`/not found/`) for unknown prompt lookups.

## Local verification

- `yarn run type-check` — clean
- `yarn vitest run` — **775/775 passing**, 24 test files
- `yarn run lint` — 0 errors (619 pre-existing warnings, untouched)

## Risk

Surgical. Only the prompts/get return shape and the test assertions tied to renamed prompts. No behavioral change in any tool, resource, or other prompt logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)