### PR TITLE
fix(ci): docker tag — use static sha- prefix so PR builds produce valid tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: 🏗️ Build and push Docker image


### PR DESCRIPTION
## Problem

Docker Build & Push fails on every PR run with:

```
ERROR: failed to build: invalid tag "ghcr.io/ziv-daniel/node-red-mcp:-9b64dc1": invalid reference format
```

Source: `.github/workflows/ci.yml` had:
```yaml
type=sha,prefix={{branch}}-
```

On `pull_request` events the `docker/metadata-action` template `{{branch}}` resolves to an empty string, so the tag becomes `:-<sha>`, which buildx rejects. On `push` to main, `{{branch}}` resolves to `main` and the tag is valid — which is why Docker has been green on main pushes but broken on every PR for as long as the workflow used branch-templated SHA prefixes.

## Fix

Replace the dynamic branch-prefixed sha tag with the action's standard `sha-` prefix:

```diff
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
```

The human-readable `type=ref,event=branch` tag is unchanged, so branch-named tags still exist for push events.

## Test plan

- [ ] CI Docker Build & Push step succeeds on this PR (was failing before)
- [ ] Resulting image is tagged `sha-<short>` and `fix-docker-tag-template` (branch-name tag)
- [ ] After merge: push to main still tags `:latest` and `:main`

## Notes

- E2E and Deploy step failures observed on main are separate issues, tracked separately.
- Production deploy to `mcp-nodered.danielshaprvt.work` is handled by Dokploy auto-pulling `:latest`, not by the SSH deploy step.