### PR TITLE
fix(ci+server): unblock E2E CORS preflight test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,7 @@ jobs:
           HTTP_ENABLED: true
           NODERED_URL: http://localhost:1880
           JWT_SECRET: ci-test-secret-minimum-32-characters-ok
+          CORS_ORIGIN: http://localhost:3000
 
       - name: ⏳ Wait for MCP server to be ready
         run: |

--- a/src/server/express-app.ts
+++ b/src/server/express-app.ts
@@ -183,7 +183,7 @@ export class ExpressApp {
           } else if (this.config.cors.origin === '*') {
             callback(null, true);
           } else {
-            callback(new Error('Not allowed by CORS'));
+            callback(null, false);
           }
         },
         credentials: this.config.cors.credentials,

--- a/src/server/express-app.ts
+++ b/src/server/express-app.ts
@@ -166,11 +166,14 @@ export class ExpressApp {
           }
 
           // Allow Claude.ai domains and configured origins
+          const configuredOrigins = Array.isArray(this.config.cors.origin)
+            ? this.config.cors.origin
+            : [this.config.cors.origin];
           const allowedOrigins = [
             'https://claude.ai',
             'https://www.claude.ai',
             'https://app.claude.ai',
-            this.config.cors.origin,
+            ...configuredOrigins,
           ].filter(Boolean);
 
           // Also allow the server's own public URL (form is served from our domain)


### PR DESCRIPTION
## Why

After PR #94 made Docker Build & Push green, the only remaining red check on `main` was **E2E Tests**.

### Root cause

The E2E test `e2e/health-check.spec.ts` sends:
```
OPTIONS /health
Origin: http://localhost:3000
Access-Control-Request-Method: GET
```

In CI:
1. The MCP server starts **without** `CORS_ORIGIN` set, so the allowlist falls back to `['https://claude.ai', 'https://www.claude.ai']`.
2. `http://localhost:3000` is not in the allowlist.
3. The cors() origin callback fires `callback(new Error('Not allowed by CORS'))`.
4. Express's default error handler turns that thrown error into **HTTP 500** — the test expected 204/200.

## Changes

**1. `.github/workflows/ci.yml`** — add `CORS_ORIGIN: http://localhost:3000` to the E2E "Start MCP server" step so localhost is in the allowlist during tests.

**2. `src/server/express-app.ts`** — change `callback(new Error('Not allowed by CORS'))` → `callback(null, false)`. Per the `cors` middleware docs, returning `false` rejects the preflight cleanly (no `Access-Control-Allow-Origin` header) without surfacing a 500. Defense in depth: even if an unknown origin hits prod, we no longer leak an error response.

## Risk

Low. The server change matches the documented cors-middleware contract for "disallowed origin" — the browser still won't get CORS headers, so the request fails CORS as intended; we just stop crashing the response with 500.

## Verification

- E2E `OPTIONS /health` should now return 204 with proper `Access-Control-Allow-Origin: http://localhost:3000`.
- All other CI jobs already green on `main` after #94.