### PR TITLE
ci: remove redundant SSH deploy step (Dokploy handles deploy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,50 +285,6 @@ jobs:
             NODE_VERSION=${{ env.NODE_VERSION }}
             YARN_VERSION=${{ env.YARN_VERSION }}
 
-  # Job 7: Deploy to production (SSH + docker compose pull)
-  deploy:
-    name: 🚀 Deploy to production
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: [quality, test, docker]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-
-    environment:
-      name: production
-      url: https://mcp.danielshaprvt.work
-
-    steps:
-      - name: 🚀 Pull new image and restart
-        uses: appleboy/ssh-action@v1.2.0
-        with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USER }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          script: |
-            set -e
-            cd ${{ secrets.DEPLOY_PATH }}
-            echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u ${{ secrets.DEPLOY_USER }} --password-stdin
-            docker compose -f docker-compose.prod.yml pull
-            docker compose -f docker-compose.prod.yml up -d --remove-orphans
-            docker image prune -f
-            echo "Deploy complete — $(docker inspect --format='{{.RepoDigests}}' ghcr.io/ziv-daniel/node-red-mcp:latest)"
-
-  # Job 8: Notify (Disabled - uncomment when notification system is configured)
-  # notify:
-  #   name: 📢 Notify
-  #   runs-on: ubuntu-latest
-  #   needs: [quality, test, docker]
-  #   if: always()
-  #
-  #   steps:
-  #     - name: 📢 Notify on success
-  #       if: success()
-  #       run: |
-  #         echo "✅ Pipeline successful!"
-  #         # Add notification logic (Slack, Discord, email, etc.)
-  #
-  #     - name: 📢 Notify on failure
-  #       if: failure()
-  #       run: |
-  #         echo "❌ Pipeline failed!"
-  #         # Add failure notification logic
+  # Deployment: Dokploy on the production host auto-pulls
+  # ghcr.io/ziv-daniel/node-red-mcp:latest after the docker job
+  # finishes pushing. No CI step needed.


### PR DESCRIPTION
## Why

The `🚀 Deploy to production` job runs an SSH-based `docker compose pull` against the prod host, but Dokploy on the prod host already auto-pulls `ghcr.io/ziv-daniel/node-red-mcp:latest` as soon as the docker job finishes pushing. The SSH step is redundant and has been failing on main, making the pipeline red even though the deploy itself succeeds (verified live on `https://mcp-nodered.danielshaprvt.work`).

## What changes

- Remove the entire `deploy:` job from `.github/workflows/ci.yml`
- Add a short comment noting that Dokploy handles deploy

## Verification

- ✅ Prod `/health` → HTTP 200 (after the docker push of `54f1885f`)
- ✅ CORS preflight from `https://claude.ai` → 204 with `Access-Control-Allow-Origin: https://claude.ai`
- The remaining 6 jobs (quality, test, e2e, security, docker, codeql) are unchanged

After merge, the next push to main should produce an all-green pipeline.
