### PR TITLE
feat(mcp): Feature 5 — Pagination + enriched filters on list tools

### DIFF
--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -232,15 +232,13 @@ export class McpNodeRedServer {
             },
             offset: {
               type: 'number',
-              description:
-                'Items to skip. When set, response is wrapped in pagination envelope.',
+              description: 'Items to skip. When set, response is wrapped in pagination envelope.',
               minimum: 0,
             },
             sortBy: {
               type: 'string',
               enum: ['label', 'nodeCount', 'disabled'],
-              description:
-                'Sort key. Secondary sort by id keeps slice boundaries deterministic.',
+              description: 'Sort key. Secondary sort by id keeps slice boundaries deterministic.',
             },
             order: {
               type: 'string',
@@ -250,8 +248,7 @@ export class McpNodeRedServer {
             },
             disabled: {
               type: 'boolean',
-              description:
-                'Filter by disabled state (true = only disabled, false = only enabled).',
+              description: 'Filter by disabled state (true = only disabled, false = only enabled).',
             },
             labelContains: {
               type: 'string',
@@ -562,8 +559,7 @@ export class McpNodeRedServer {
             },
             offset: {
               type: 'number',
-              description:
-                'Matches to skip. When set, response is wrapped in pagination envelope.',
+              description: 'Matches to skip. When set, response is wrapped in pagination envelope.',
               minimum: 0,
             },
           },
@@ -630,9 +626,7 @@ export class McpNodeRedServer {
           const sortBy = args?.sortBy as string | undefined;
           const order = args?.order as string | undefined;
           if (sortBy !== undefined && !FLOW_SORT_KEYS.includes(sortBy as FlowSortKey)) {
-            throw new Error(
-              `Invalid sortBy: must be one of ${FLOW_SORT_KEYS.join(', ')}`
-            );
+            throw new Error(`Invalid sortBy: must be one of ${FLOW_SORT_KEYS.join(', ')}`);
           }
           if (order !== undefined && order !== 'asc' && order !== 'desc') {
             throw new Error('Invalid order: must be "asc" or "desc"');
@@ -645,7 +639,9 @@ export class McpNodeRedServer {
           if (typeof args?.labelContains === 'string') {
             const q = args.labelContains.toLowerCase();
             flowData = flowData.filter((f: any) =>
-              String(f?.label ?? '').toLowerCase().includes(q)
+              String(f?.label ?? '')
+                .toLowerCase()
+                .includes(q)
             );
           }
 
@@ -763,8 +759,7 @@ export class McpNodeRedServer {
         case 'get_installed_modules': {
           const installedModules = await this.nodeRedClient.getInstalledModules();
           const queryFilter = args?.query;
-          const hasNewParams =
-            isPaginated(args) || typeof queryFilter === 'string';
+          const hasNewParams = isPaginated(args) || typeof queryFilter === 'string';
 
           if (!hasNewParams) {
             return {

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -653,7 +653,7 @@ export class McpNodeRedServer {
             flowData = stableSortBy(
               flowData,
               flowSortKeyFn(sortBy as FlowSortKey),
-              (order as 'asc' | 'desc') ?? 'asc'
+              order as 'asc' | 'desc' | undefined
             );
           }
 
@@ -880,15 +880,18 @@ export class McpNodeRedServer {
               if (typeFilterLower && !nodeTypeLower.includes(typeFilterLower)) continue;
               if (nodeTypePrefixLower && !nodeTypeLower.startsWith(nodeTypePrefixLower)) continue;
               if (queryLower) {
-                const nameMatch = (node.name ?? '').toLowerCase().includes(queryLower);
-                const propMatch = Object.entries(node).some(
-                  ([k, v]) =>
-                    !SEARCH_SKIP_PROPS.has(k) &&
-                    k !== 'name' &&
-                    typeof v === 'string' &&
-                    v.toLowerCase().includes(queryLower)
-                );
-                if (!nameMatch && !propMatch) continue;
+                let matched = (node.name ?? '').toLowerCase().includes(queryLower);
+                if (!matched) {
+                  for (const k in node) {
+                    if (SEARCH_SKIP_PROPS.has(k) || k === 'name') continue;
+                    const v = (node as Record<string, unknown>)[k];
+                    if (typeof v === 'string' && v.toLowerCase().includes(queryLower)) {
+                      matched = true;
+                      break;
+                    }
+                  }
+                }
+                if (!matched) continue;
               }
               allMatches.push({
                 nodeId: node.id,

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -28,6 +28,7 @@ import {
 import type { NodeRedCredentials } from '../types/oauth.js';
 import { validateRequired, validateTypes } from '../utils/error-handling.js';
 
+import { applyPagination, isPaginated, stableSortBy } from './pagination.js';
 import { SSEHandler } from './sse-handler.js';
 
 const SEARCH_RESULTS_LIMIT = 10;
@@ -96,6 +97,16 @@ function validateFlowOrThrow(flowData: { nodes?: unknown[] }): void {
   if (!validation.valid) {
     throw new Error(`Validation failed:\n${validation.errors.map(e => `- ${e}`).join('\n')}`);
   }
+}
+
+const FLOW_SORT_KEYS = ['label', 'nodeCount', 'disabled'] as const;
+type FlowSortKey = (typeof FLOW_SORT_KEYS)[number];
+
+function flowSortKeyFn(field: FlowSortKey): (f: any) => string | number | boolean {
+  if (field === 'label') return (f: any) => String(f?.label ?? '').toLowerCase();
+  if (field === 'nodeCount')
+    return (f: any) => (typeof f?.nodeCount === 'number' ? f.nodeCount : (f?.nodes?.length ?? 0));
+  return (f: any) => Boolean(f?.disabled);
 }
 
 export class McpNodeRedServer {
@@ -194,7 +205,7 @@ export class McpNodeRedServer {
       {
         name: 'get_flows',
         description:
-          'Get Node-RED flows with flexible filtering (summary info by default, use includeDetails for full data)',
+          'Get Node-RED flows with flexible filtering (summary info by default, use includeDetails for full data). Supports pagination (limit/offset), sorting (label/nodeCount/disabled), and filtering by disabled state or label substring.',
         annotations: { readOnlyHint: true },
         inputSchema: {
           type: 'object',
@@ -211,6 +222,40 @@ export class McpNodeRedServer {
               description:
                 'Flow types to include (default: ["tab", "subflow"]). Options: "tab" (main flows), "subflow" (reusable subflows)',
               default: ['tab', 'subflow'],
+            },
+            limit: {
+              type: 'number',
+              description:
+                'Maximum items to return (1-500). When set, response is wrapped in pagination envelope { items, total, limit, offset, hasMore }.',
+              minimum: 1,
+              maximum: 500,
+            },
+            offset: {
+              type: 'number',
+              description:
+                'Items to skip. When set, response is wrapped in pagination envelope.',
+              minimum: 0,
+            },
+            sortBy: {
+              type: 'string',
+              enum: ['label', 'nodeCount', 'disabled'],
+              description:
+                'Sort key. Secondary sort by id keeps slice boundaries deterministic.',
+            },
+            order: {
+              type: 'string',
+              enum: ['asc', 'desc'],
+              description: 'Sort order (default: asc).',
+              default: 'asc',
+            },
+            disabled: {
+              type: 'boolean',
+              description:
+                'Filter by disabled state (true = only disabled, false = only enabled).',
+            },
+            labelContains: {
+              type: 'string',
+              description: 'Case-insensitive substring filter on flow label.',
             },
           },
           required: [],
@@ -357,11 +402,28 @@ export class McpNodeRedServer {
       },
       {
         name: 'get_installed_modules',
-        description: 'Get list of currently installed Node-RED palette modules',
+        description:
+          'Get list of currently installed Node-RED palette modules. Supports pagination (limit/offset) and a case-insensitive substring filter (query). When any of these is provided, response is wrapped in pagination envelope.',
         annotations: { readOnlyHint: true },
         inputSchema: {
           type: 'object',
-          properties: {},
+          properties: {
+            query: {
+              type: 'string',
+              description: 'Case-insensitive substring filter on module name.',
+            },
+            limit: {
+              type: 'number',
+              description: 'Maximum items to return (1-500).',
+              minimum: 1,
+              maximum: 500,
+            },
+            offset: {
+              type: 'number',
+              description: 'Items to skip.',
+              minimum: 0,
+            },
+          },
           required: [],
         },
       },
@@ -462,7 +524,7 @@ export class McpNodeRedServer {
       {
         name: 'search_flows',
         description:
-          'Search for nodes in Node-RED flows by type, name, or property value. At least one parameter is required.',
+          'Search for nodes in Node-RED flows by type, name, or property value. At least one search parameter is required. Supports pagination (limit/offset replaces the internal 10-cap), node type prefix filter, and flow exclusion list.',
         annotations: { readOnlyHint: true },
         inputSchema: {
           type: 'object',
@@ -481,15 +543,56 @@ export class McpNodeRedServer {
               type: 'string',
               description: 'Restrict search to a specific flow ID',
             },
+            nodeTypePrefix: {
+              type: 'string',
+              description:
+                'Case-insensitive prefix match on node type — useful for namespaced types.',
+            },
+            excludeFlowIds: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Exclude these flow IDs from the search.',
+            },
+            limit: {
+              type: 'number',
+              description:
+                'Maximum matches to return (1-500). When set, replaces the default 10-cap and wraps response in pagination envelope.',
+              minimum: 1,
+              maximum: 500,
+            },
+            offset: {
+              type: 'number',
+              description:
+                'Matches to skip. When set, response is wrapped in pagination envelope.',
+              minimum: 0,
+            },
           },
           required: [],
         },
       },
       {
         name: 'get_flow_state',
-        description: 'Get the runtime state of Node-RED flows (running or stopped)',
+        description:
+          'Get the runtime state of Node-RED flows (running or stopped). Supports pagination over the per-flow array via limit/offset.',
         annotations: { readOnlyHint: true },
-        inputSchema: { type: 'object', properties: {}, required: [] },
+        inputSchema: {
+          type: 'object',
+          properties: {
+            limit: {
+              type: 'number',
+              description:
+                'Maximum flows to return (1-500). When set, response is wrapped in pagination envelope (state remains at top level).',
+              minimum: 1,
+              maximum: 500,
+            },
+            offset: {
+              type: 'number',
+              description: 'Flows to skip.',
+              minimum: 0,
+            },
+          },
+          required: [],
+        },
       },
       {
         name: 'get_settings',
@@ -517,19 +620,50 @@ export class McpNodeRedServer {
     try {
       switch (name) {
         // Core Flow Management Tools
-        case 'get_flows':
+        case 'get_flows': {
           const includeDetails = args?.includeDetails || false;
           const types = args?.types || ['tab', 'subflow'];
-          const flowData = includeDetails
+          let flowData: any[] = includeDetails
             ? await this.nodeRedClient.getFlows()
             : await this.nodeRedClient.getFlowSummaries(types);
 
-          result = {
-            success: true,
-            data: flowData,
-            timestamp,
-          };
+          const sortBy = args?.sortBy as string | undefined;
+          const order = args?.order as string | undefined;
+          if (sortBy !== undefined && !FLOW_SORT_KEYS.includes(sortBy as FlowSortKey)) {
+            throw new Error(
+              `Invalid sortBy: must be one of ${FLOW_SORT_KEYS.join(', ')}`
+            );
+          }
+          if (order !== undefined && order !== 'asc' && order !== 'desc') {
+            throw new Error('Invalid order: must be "asc" or "desc"');
+          }
+
+          if (args?.disabled !== undefined) {
+            const wantDisabled = Boolean(args.disabled);
+            flowData = flowData.filter((f: any) => Boolean(f?.disabled) === wantDisabled);
+          }
+          if (typeof args?.labelContains === 'string') {
+            const q = args.labelContains.toLowerCase();
+            flowData = flowData.filter((f: any) =>
+              String(f?.label ?? '').toLowerCase().includes(q)
+            );
+          }
+
+          if (sortBy) {
+            flowData = stableSortBy(
+              flowData,
+              flowSortKeyFn(sortBy as FlowSortKey),
+              (order as 'asc' | 'desc') ?? 'asc'
+            );
+          }
+
+          if (isPaginated(args)) {
+            result = { success: true, data: applyPagination(flowData, args), timestamp };
+          } else {
+            result = { success: true, data: flowData, timestamp };
+          }
           break;
+        }
 
         case 'get_flow':
           validateRequired(args, ['flowId']);
@@ -630,16 +764,34 @@ export class McpNodeRedServer {
             ],
           };
 
-        case 'get_installed_modules':
+        case 'get_installed_modules': {
           const installedModules = await this.nodeRedClient.getInstalledModules();
-          return {
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify(installedModules, null, 2),
-              },
-            ],
-          };
+          const queryFilter = args?.query;
+          const hasNewParams =
+            isPaginated(args) || typeof queryFilter === 'string';
+
+          if (!hasNewParams) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify(installedModules, null, 2),
+                },
+              ],
+            };
+          }
+
+          let modules: any[] = Array.isArray(installedModules) ? installedModules : [];
+          if (typeof queryFilter === 'string') {
+            const q = queryFilter.toLowerCase();
+            modules = modules.filter((m: any) => {
+              const name = typeof m === 'string' ? m : (m?.name ?? m?.id ?? '');
+              return String(name).toLowerCase().includes(q);
+            });
+          }
+          result = { success: true, data: applyPagination(modules, args), timestamp };
+          break;
+        }
 
         case 'get_context': {
           const scope = args?.scope || 'global';
@@ -703,21 +855,30 @@ export class McpNodeRedServer {
           const typeFilter = args?.type as string | undefined;
           const query = args?.query as string | undefined;
           const filterFlowId = args?.flowId as string | undefined;
+          const nodeTypePrefix = args?.nodeTypePrefix as string | undefined;
+          const excludeFlowIds = Array.isArray(args?.excludeFlowIds)
+            ? new Set(args.excludeFlowIds as string[])
+            : undefined;
 
-          if (!typeFilter && !query && !filterFlowId) {
-            throw new Error('At least one search parameter is required: type, query, or flowId');
+          if (!typeFilter && !query && !filterFlowId && !nodeTypePrefix) {
+            throw new Error(
+              'At least one search parameter is required: type, query, flowId, or nodeTypePrefix'
+            );
           }
 
           const flows = await this.nodeRedClient.getFlows();
           const typeFilterLower = typeFilter?.toLowerCase();
           const queryLower = query?.toLowerCase();
-          const matches: FlowSearchMatch[] = [];
-          let total = 0;
+          const nodeTypePrefixLower = nodeTypePrefix?.toLowerCase();
+          const allMatches: FlowSearchMatch[] = [];
 
           for (const flow of flows) {
             if (filterFlowId && flow.id !== filterFlowId) continue;
+            if (excludeFlowIds?.has(flow.id)) continue;
             for (const node of flow.nodes ?? []) {
-              if (typeFilterLower && !node.type.toLowerCase().includes(typeFilterLower)) continue;
+              const nodeTypeLower = node.type.toLowerCase();
+              if (typeFilterLower && !nodeTypeLower.includes(typeFilterLower)) continue;
+              if (nodeTypePrefixLower && !nodeTypeLower.startsWith(nodeTypePrefixLower)) continue;
               if (queryLower) {
                 const nameMatch = (node.name ?? '').toLowerCase().includes(queryLower);
                 const propMatch = Object.entries(node).some(
@@ -729,29 +890,39 @@ export class McpNodeRedServer {
                 );
                 if (!nameMatch && !propMatch) continue;
               }
-              total++;
-              if (matches.length < SEARCH_RESULTS_LIMIT) {
-                matches.push({
-                  nodeId: node.id,
-                  nodeType: node.type,
-                  nodeName: node.name ?? '',
-                  flowId: flow.id,
-                  flowLabel: flow.label ?? '',
-                });
-              }
+              allMatches.push({
+                nodeId: node.id,
+                nodeType: node.type,
+                nodeName: node.name ?? '',
+                flowId: flow.id,
+                flowLabel: flow.label ?? '',
+              });
             }
           }
 
-          result = {
-            success: true,
-            data: { matches, total },
-            timestamp,
-          };
+          if (isPaginated(args)) {
+            result = { success: true, data: applyPagination(allMatches, args), timestamp };
+          } else {
+            const total = allMatches.length;
+            const matches = allMatches.slice(0, SEARCH_RESULTS_LIMIT);
+            result = { success: true, data: { matches, total }, timestamp };
+          }
           break;
         }
 
         case 'get_flow_state': {
-          result = { success: true, data: await this.nodeRedClient.getFlowStatus(), timestamp };
+          const status: any = await this.nodeRedClient.getFlowStatus();
+          if (isPaginated(args)) {
+            const flows = Array.isArray(status?.flows) ? status.flows : [];
+            const envelope = applyPagination(flows, args);
+            result = {
+              success: true,
+              data: { state: status?.state, ...envelope },
+              timestamp,
+            };
+          } else {
+            result = { success: true, data: status, timestamp };
+          }
           break;
         }
 

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -650,11 +650,7 @@ export class McpNodeRedServer {
           }
 
           if (sortBy) {
-            flowData = stableSortBy(
-              flowData,
-              flowSortKeyFn(sortBy as FlowSortKey),
-              order as 'asc' | 'desc' | undefined
-            );
+            flowData = stableSortBy(flowData, flowSortKeyFn(sortBy as FlowSortKey), order);
           }
 
           if (isPaginated(args)) {

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -882,7 +882,7 @@ export class McpNodeRedServer {
               if (queryLower) {
                 let matched = (node.name ?? '').toLowerCase().includes(queryLower);
                 if (!matched) {
-                  for (const k in node) {
+                  for (const k of Object.keys(node)) {
                     if (SEARCH_SKIP_PROPS.has(k) || k === 'name') continue;
                     const v = (node as Record<string, unknown>)[k];
                     if (typeof v === 'string' && v.toLowerCase().includes(queryLower)) {

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -28,7 +28,14 @@ import {
 import type { NodeRedCredentials } from '../types/oauth.js';
 import { validateRequired, validateTypes } from '../utils/error-handling.js';
 
-import { applyPagination, isPaginated, stableSortBy } from './pagination.js';
+import {
+  applyPagination,
+  caseInsensitiveIncludes,
+  isPaginated,
+  parsePagination,
+  parseSort,
+  stableSortBy,
+} from './pagination.js';
 import { SSEHandler } from './sse-handler.js';
 
 const SEARCH_RESULTS_LIMIT = 10;
@@ -102,12 +109,11 @@ function validateFlowOrThrow(flowData: { nodes?: unknown[] }): void {
 const FLOW_SORT_KEYS = ['label', 'nodeCount', 'disabled'] as const;
 type FlowSortKey = (typeof FLOW_SORT_KEYS)[number];
 
-function flowSortKeyFn(field: FlowSortKey): (f: any) => string | number | boolean {
-  if (field === 'label') return (f: any) => String(f?.label ?? '').toLowerCase();
-  if (field === 'nodeCount')
-    return (f: any) => (typeof f?.nodeCount === 'number' ? f.nodeCount : (f?.nodes?.length ?? 0));
-  return (f: any) => Boolean(f?.disabled);
-}
+const FLOW_SORT_KEY_FNS: Record<FlowSortKey, (f: any) => string | number | boolean> = {
+  label: f => String(f?.label ?? '').toLowerCase(),
+  nodeCount: f => (typeof f?.nodeCount === 'number' ? f.nodeCount : (f?.nodes?.length ?? 0)),
+  disabled: f => Boolean(f?.disabled),
+};
 
 export class McpNodeRedServer {
   private server: Server;
@@ -237,7 +243,7 @@ export class McpNodeRedServer {
             },
             sortBy: {
               type: 'string',
-              enum: ['label', 'nodeCount', 'disabled'],
+              enum: [...FLOW_SORT_KEYS],
               description: 'Sort key. Secondary sort by id keeps slice boundaries deterministic.',
             },
             order: {
@@ -623,30 +629,19 @@ export class McpNodeRedServer {
             ? await this.nodeRedClient.getFlows()
             : await this.nodeRedClient.getFlowSummaries(types);
 
-          const sortBy = args?.sortBy as string | undefined;
-          const order = args?.order as string | undefined;
-          if (sortBy !== undefined && !FLOW_SORT_KEYS.includes(sortBy as FlowSortKey)) {
-            throw new Error(`Invalid sortBy: must be one of ${FLOW_SORT_KEYS.join(', ')}`);
-          }
-          if (order !== undefined && order !== 'asc' && order !== 'desc') {
-            throw new Error('Invalid order: must be "asc" or "desc"');
-          }
+          const { sortBy, order } = parseSort(args, FLOW_SORT_KEYS);
 
           if (args?.disabled !== undefined) {
             const wantDisabled = Boolean(args.disabled);
             flowData = flowData.filter((f: any) => Boolean(f?.disabled) === wantDisabled);
           }
           if (typeof args?.labelContains === 'string') {
-            const q = args.labelContains.toLowerCase();
-            flowData = flowData.filter((f: any) =>
-              String(f?.label ?? '')
-                .toLowerCase()
-                .includes(q)
-            );
+            const q = args.labelContains;
+            flowData = flowData.filter((f: any) => caseInsensitiveIncludes(f?.label, q));
           }
 
           if (sortBy) {
-            flowData = stableSortBy(flowData, flowSortKeyFn(sortBy as FlowSortKey), order);
+            flowData = stableSortBy(flowData, FLOW_SORT_KEY_FNS[sortBy], order);
           }
 
           if (isPaginated(args)) {
@@ -774,10 +769,9 @@ export class McpNodeRedServer {
 
           let modules: any[] = Array.isArray(installedModules) ? installedModules : [];
           if (typeof queryFilter === 'string') {
-            const q = queryFilter.toLowerCase();
             modules = modules.filter((m: any) => {
               const name = typeof m === 'string' ? m : (m?.name ?? m?.id ?? '');
-              return String(name).toLowerCase().includes(q);
+              return caseInsensitiveIncludes(name, queryFilter);
             });
           }
           result = { success: true, data: applyPagination(modules, args), timestamp };
@@ -861,7 +855,14 @@ export class McpNodeRedServer {
           const typeFilterLower = typeFilter?.toLowerCase();
           const queryLower = query?.toLowerCase();
           const nodeTypePrefixLower = nodeTypePrefix?.toLowerCase();
-          const allMatches: FlowSearchMatch[] = [];
+
+          const paginated = isPaginated(args);
+          const { limit: pageLimit, offset: pageOffset } = paginated
+            ? parsePagination(args)
+            : { limit: SEARCH_RESULTS_LIMIT, offset: 0 };
+          const windowEnd = pageOffset + pageLimit;
+          const matches: FlowSearchMatch[] = [];
+          let total = 0;
 
           for (const flow of flows) {
             if (filterFlowId && flow.id !== filterFlowId) continue;
@@ -884,21 +885,32 @@ export class McpNodeRedServer {
                 }
                 if (!matched) continue;
               }
-              allMatches.push({
-                nodeId: node.id,
-                nodeType: node.type,
-                nodeName: node.name ?? '',
-                flowId: flow.id,
-                flowLabel: flow.label ?? '',
-              });
+              if (total >= pageOffset && total < windowEnd) {
+                matches.push({
+                  nodeId: node.id,
+                  nodeType: node.type,
+                  nodeName: node.name ?? '',
+                  flowId: flow.id,
+                  flowLabel: flow.label ?? '',
+                });
+              }
+              total++;
             }
           }
 
-          if (isPaginated(args)) {
-            result = { success: true, data: applyPagination(allMatches, args), timestamp };
+          if (paginated) {
+            result = {
+              success: true,
+              data: {
+                items: matches,
+                total,
+                limit: pageLimit,
+                offset: pageOffset,
+                hasMore: pageOffset + matches.length < total,
+              },
+              timestamp,
+            };
           } else {
-            const total = allMatches.length;
-            const matches = allMatches.slice(0, SEARCH_RESULTS_LIMIT);
             result = { success: true, data: { matches, total }, timestamp };
           }
           break;

--- a/src/server/pagination-integration.test.ts
+++ b/src/server/pagination-integration.test.ts
@@ -138,9 +138,7 @@ describe('Pagination + filters', () => {
     });
 
     it('sorts by nodeCount descending', async () => {
-      const parsed = parse(
-        await mcp.callTool('get_flows', { sortBy: 'nodeCount', order: 'desc' })
-      );
+      const parsed = parse(await mcp.callTool('get_flows', { sortBy: 'nodeCount', order: 'desc' }));
       expect(parsed.data.map((f: any) => f.id)).toEqual(['c', 'b', 'a', 'd']);
     });
 
@@ -188,7 +186,12 @@ describe('Pagination + filters', () => {
     beforeEach(() => {
       mockNodeRedClient.getFlows.mockResolvedValue([
         { id: 'tab-1', type: 'tab', label: 'Big', nodes: manyNodes },
-        { id: 'tab-2', type: 'tab', label: 'MQTT', nodes: [namespacedNodes[0], namespacedNodes[1]] },
+        {
+          id: 'tab-2',
+          type: 'tab',
+          label: 'MQTT',
+          nodes: [namespacedNodes[0], namespacedNodes[1]],
+        },
         { id: 'tab-3', type: 'tab', label: 'Debug', nodes: [namespacedNodes[2]] },
       ]);
     });
@@ -200,9 +203,7 @@ describe('Pagination + filters', () => {
     });
 
     it('replaces 10-cap with envelope when limit is set', async () => {
-      const parsed = parse(
-        await mcp.callTool('search_flows', { type: 'function', limit: 12 })
-      );
+      const parsed = parse(await mcp.callTool('search_flows', { type: 'function', limit: 12 }));
       expect(parsed.data.items).toHaveLength(12);
       expect(parsed.data.total).toBe(15);
       expect(parsed.data.hasMore).toBe(true);
@@ -218,9 +219,7 @@ describe('Pagination + filters', () => {
     });
 
     it('filters by nodeTypePrefix', async () => {
-      const parsed = parse(
-        await mcp.callTool('search_flows', { nodeTypePrefix: 'mqtt' })
-      );
+      const parsed = parse(await mcp.callTool('search_flows', { nodeTypePrefix: 'mqtt' }));
       expect(parsed.data.total).toBe(2);
       expect(parsed.data.matches.every((m: any) => m.nodeType.startsWith('mqtt'))).toBe(true);
     });
@@ -236,9 +235,7 @@ describe('Pagination + filters', () => {
     });
 
     it('accepts nodeTypePrefix alone as a valid search parameter', async () => {
-      const parsed = parse(
-        await mcp.callTool('search_flows', { nodeTypePrefix: 'deb' })
-      );
+      const parsed = parse(await mcp.callTool('search_flows', { nodeTypePrefix: 'deb' }));
       expect(parsed.success).toBe(true);
       expect(parsed.data.total).toBe(1);
       expect(parsed.data.matches[0].nodeId).toBe('d1');
@@ -274,9 +271,7 @@ describe('Pagination + filters', () => {
     });
 
     it('filters by query and returns envelope', async () => {
-      const parsed = parse(
-        await mcp.callTool('get_installed_modules', { query: 'contrib' })
-      );
+      const parsed = parse(await mcp.callTool('get_installed_modules', { query: 'contrib' }));
       expect(parsed.success).toBe(true);
       expect(parsed.data.total).toBe(2);
       expect(parsed.data.items.every((m: any) => m.name.includes('contrib'))).toBe(true);
@@ -296,9 +291,7 @@ describe('Pagination + filters', () => {
         'node-red-contrib-foo',
         'node-red-bar',
       ]);
-      const parsed = parse(
-        await mcp.callTool('get_installed_modules', { query: 'contrib' })
-      );
+      const parsed = parse(await mcp.callTool('get_installed_modules', { query: 'contrib' }));
       expect(parsed.data.items).toEqual(['node-red-contrib-foo']);
     });
   });

--- a/src/server/pagination-integration.test.ts
+++ b/src/server/pagination-integration.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Integration tests for pagination + enriched filters across the 4 paginatable tools:
+ *   get_flows, search_flows, get_installed_modules, get_flow_state.
+ *
+ * Backwards-compat contract verified here:
+ *   - Tools return their LEGACY shape when no pagination params are passed
+ *     (array for get_flows; { matches, total } for search_flows; raw text dump
+ *     for get_installed_modules; raw status for get_flow_state).
+ *   - Tools wrap output in the pagination envelope only when limit/offset (or,
+ *     for get_installed_modules, query) is provided.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { McpNodeRedServer } from './mcp-server.js';
+
+const mockNodeRedClient = {
+  getFlows: vi.fn(),
+  getFlowSummaries: vi.fn(),
+  getFlow: vi.fn(),
+  createFlow: vi.fn(),
+  updateFlow: vi.fn(),
+  enableFlow: vi.fn(),
+  disableFlow: vi.fn(),
+  searchModules: vi.fn(),
+  installModule: vi.fn(),
+  getInstalledModules: vi.fn(),
+  testConnection: vi.fn().mockResolvedValue(true),
+  getRuntimeInfo: vi.fn(),
+  getGlobalContext: vi.fn(),
+  setGlobalContext: vi.fn(),
+  deleteGlobalContext: vi.fn(),
+  getFlowContext: vi.fn(),
+  setFlowContext: vi.fn(),
+  deleteFlow: vi.fn(),
+  getFlowStatus: vi.fn(),
+  getSettings: vi.fn(),
+};
+
+const mockSSEHandler = {
+  start: vi.fn(),
+  stop: vi.fn(),
+  broadcast: vi.fn(),
+  destroy: vi.fn(),
+};
+
+vi.mock('../services/nodered-api.js', () => ({
+  NodeRedAPIClient: class {
+    constructor() {
+      return mockNodeRedClient;
+    }
+  },
+}));
+
+vi.mock('./sse-handler.js', () => ({
+  SSEHandler: class {
+    constructor() {
+      return mockSSEHandler;
+    }
+  },
+}));
+
+vi.mock('@modelcontextprotocol/sdk/server/index.js', () => ({
+  Server: class {
+    handlers = new Map();
+    setRequestHandler = vi.fn((schema: any, handler: any) => {
+      this.handlers.set(schema, handler);
+    });
+    connect = vi.fn();
+  },
+}));
+
+function parse(result: any) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('Pagination + filters', () => {
+  let mcp: McpNodeRedServer;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNodeRedClient.testConnection.mockResolvedValue(true);
+    mcp = new McpNodeRedServer();
+  });
+
+  describe('get_flows', () => {
+    const summaries = [
+      { id: 'b', label: 'Beta', nodeCount: 5, disabled: false },
+      { id: 'a', label: 'Alpha', nodeCount: 2, disabled: true },
+      { id: 'c', label: 'Charlie alpha', nodeCount: 8, disabled: false },
+      { id: 'd', label: 'Delta', nodeCount: 1, disabled: false },
+    ];
+
+    beforeEach(() => {
+      mockNodeRedClient.getFlowSummaries.mockResolvedValue(summaries);
+      mockNodeRedClient.getFlows.mockResolvedValue(summaries);
+    });
+
+    it('returns a plain array when no pagination params (legacy shape)', async () => {
+      const parsed = parse(await mcp.callTool('get_flows', {}));
+      expect(parsed.success).toBe(true);
+      expect(Array.isArray(parsed.data)).toBe(true);
+      expect(parsed.data).toHaveLength(4);
+    });
+
+    it('returns pagination envelope when limit is provided', async () => {
+      const parsed = parse(await mcp.callTool('get_flows', { limit: 2 }));
+      expect(parsed.data).toMatchObject({
+        total: 4,
+        limit: 2,
+        offset: 0,
+        hasMore: true,
+      });
+      expect(parsed.data.items).toHaveLength(2);
+    });
+
+    it('returns pagination envelope when offset is provided', async () => {
+      const parsed = parse(await mcp.callTool('get_flows', { offset: 3 }));
+      expect(parsed.data.items).toHaveLength(1);
+      expect(parsed.data.hasMore).toBe(false);
+    });
+
+    it('filters by disabled state', async () => {
+      const parsed = parse(await mcp.callTool('get_flows', { disabled: true }));
+      expect(parsed.data).toHaveLength(1);
+      expect(parsed.data[0].id).toBe('a');
+    });
+
+    it('filters by labelContains (case-insensitive)', async () => {
+      const parsed = parse(await mcp.callTool('get_flows', { labelContains: 'alpha' }));
+      const ids = parsed.data.map((f: any) => f.id).sort();
+      expect(ids).toEqual(['a', 'c']);
+    });
+
+    it('sorts by label ascending', async () => {
+      const parsed = parse(await mcp.callTool('get_flows', { sortBy: 'label' }));
+      expect(parsed.data.map((f: any) => f.id)).toEqual(['a', 'b', 'c', 'd']);
+    });
+
+    it('sorts by nodeCount descending', async () => {
+      const parsed = parse(
+        await mcp.callTool('get_flows', { sortBy: 'nodeCount', order: 'desc' })
+      );
+      expect(parsed.data.map((f: any) => f.id)).toEqual(['c', 'b', 'a', 'd']);
+    });
+
+    it('returns an error result on invalid sortBy', async () => {
+      const parsed = parse(await mcp.callTool('get_flows', { sortBy: 'bogus' }));
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toMatch(/Invalid sortBy/);
+    });
+
+    it('returns an error result on invalid limit (not 500)', async () => {
+      const parsed = parse(await mcp.callTool('get_flows', { limit: 9999 }));
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toMatch(/Invalid limit/);
+    });
+
+    it('combines filter + sort + pagination deterministically', async () => {
+      const parsed = parse(
+        await mcp.callTool('get_flows', {
+          labelContains: 'a',
+          sortBy: 'label',
+          order: 'asc',
+          limit: 1,
+          offset: 1,
+        })
+      );
+      expect(parsed.data.total).toBe(3);
+      expect(parsed.data.items).toHaveLength(1);
+      expect(parsed.data.items[0].id).toBe('c');
+    });
+  });
+
+  describe('search_flows', () => {
+    const manyNodes = Array.from({ length: 15 }, (_, i) => ({
+      id: `fn-${i}`,
+      type: 'function',
+      name: `Func ${i}`,
+      z: 'tab-1',
+    }));
+    const namespacedNodes = [
+      { id: 'm1', type: 'mqtt out', name: 'pub', z: 'tab-2' },
+      { id: 'm2', type: 'mqtt in', name: 'sub', z: 'tab-2' },
+      { id: 'd1', type: 'debug', name: 'd', z: 'tab-3' },
+    ];
+
+    beforeEach(() => {
+      mockNodeRedClient.getFlows.mockResolvedValue([
+        { id: 'tab-1', type: 'tab', label: 'Big', nodes: manyNodes },
+        { id: 'tab-2', type: 'tab', label: 'MQTT', nodes: [namespacedNodes[0], namespacedNodes[1]] },
+        { id: 'tab-3', type: 'tab', label: 'Debug', nodes: [namespacedNodes[2]] },
+      ]);
+    });
+
+    it('preserves legacy 10-cap when no pagination params', async () => {
+      const parsed = parse(await mcp.callTool('search_flows', { type: 'function' }));
+      expect(parsed.data.matches).toHaveLength(10);
+      expect(parsed.data.total).toBe(15);
+    });
+
+    it('replaces 10-cap with envelope when limit is set', async () => {
+      const parsed = parse(
+        await mcp.callTool('search_flows', { type: 'function', limit: 12 })
+      );
+      expect(parsed.data.items).toHaveLength(12);
+      expect(parsed.data.total).toBe(15);
+      expect(parsed.data.hasMore).toBe(true);
+    });
+
+    it('paginates with offset', async () => {
+      const parsed = parse(
+        await mcp.callTool('search_flows', { type: 'function', limit: 5, offset: 10 })
+      );
+      expect(parsed.data.items).toHaveLength(5);
+      expect(parsed.data.offset).toBe(10);
+      expect(parsed.data.hasMore).toBe(false);
+    });
+
+    it('filters by nodeTypePrefix', async () => {
+      const parsed = parse(
+        await mcp.callTool('search_flows', { nodeTypePrefix: 'mqtt' })
+      );
+      expect(parsed.data.total).toBe(2);
+      expect(parsed.data.matches.every((m: any) => m.nodeType.startsWith('mqtt'))).toBe(true);
+    });
+
+    it('excludes flows via excludeFlowIds', async () => {
+      const parsed = parse(
+        await mcp.callTool('search_flows', {
+          nodeTypePrefix: 'mqtt',
+          excludeFlowIds: ['tab-2'],
+        })
+      );
+      expect(parsed.data.total).toBe(0);
+    });
+
+    it('accepts nodeTypePrefix alone as a valid search parameter', async () => {
+      const parsed = parse(
+        await mcp.callTool('search_flows', { nodeTypePrefix: 'deb' })
+      );
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.total).toBe(1);
+      expect(parsed.data.matches[0].nodeId).toBe('d1');
+    });
+  });
+
+  describe('get_installed_modules', () => {
+    const modules = [
+      { name: 'node-red-contrib-mqtt' },
+      { name: 'node-red-dashboard' },
+      { name: 'node-red-contrib-influxdb' },
+      { name: 'node-red-node-email' },
+    ];
+
+    beforeEach(() => {
+      mockNodeRedClient.getInstalledModules.mockResolvedValue(modules);
+    });
+
+    it('returns raw JSON dump when no pagination/query params (legacy)', async () => {
+      const result = await mcp.callTool('get_installed_modules', {});
+      const text = result.content[0].text;
+      const parsed = JSON.parse(text);
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(4);
+    });
+
+    it('returns envelope when limit is provided', async () => {
+      const parsed = parse(await mcp.callTool('get_installed_modules', { limit: 2 }));
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.items).toHaveLength(2);
+      expect(parsed.data.total).toBe(4);
+      expect(parsed.data.hasMore).toBe(true);
+    });
+
+    it('filters by query and returns envelope', async () => {
+      const parsed = parse(
+        await mcp.callTool('get_installed_modules', { query: 'contrib' })
+      );
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.total).toBe(2);
+      expect(parsed.data.items.every((m: any) => m.name.includes('contrib'))).toBe(true);
+    });
+
+    it('combines query + pagination', async () => {
+      const parsed = parse(
+        await mcp.callTool('get_installed_modules', { query: 'node-red', limit: 1, offset: 1 })
+      );
+      expect(parsed.data.total).toBe(4);
+      expect(parsed.data.items).toHaveLength(1);
+      expect(parsed.data.offset).toBe(1);
+    });
+
+    it('handles string module entries', async () => {
+      mockNodeRedClient.getInstalledModules.mockResolvedValueOnce([
+        'node-red-contrib-foo',
+        'node-red-bar',
+      ]);
+      const parsed = parse(
+        await mcp.callTool('get_installed_modules', { query: 'contrib' })
+      );
+      expect(parsed.data.items).toEqual(['node-red-contrib-foo']);
+    });
+  });
+
+  describe('get_flow_state', () => {
+    const status = {
+      state: 'start',
+      flows: Array.from({ length: 6 }, (_, i) => ({ id: `f-${i}`, state: 'running' })),
+    };
+
+    beforeEach(() => {
+      mockNodeRedClient.getFlowStatus.mockResolvedValue(status);
+    });
+
+    it('returns raw status when no pagination params (legacy)', async () => {
+      const parsed = parse(await mcp.callTool('get_flow_state', {}));
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.state).toBe('start');
+      expect(parsed.data.flows).toHaveLength(6);
+    });
+
+    it('wraps flows in envelope when limit is set, preserving top-level state', async () => {
+      const parsed = parse(await mcp.callTool('get_flow_state', { limit: 2 }));
+      expect(parsed.data.state).toBe('start');
+      expect(parsed.data.items).toHaveLength(2);
+      expect(parsed.data.total).toBe(6);
+      expect(parsed.data.hasMore).toBe(true);
+    });
+
+    it('paginates via offset', async () => {
+      const parsed = parse(await mcp.callTool('get_flow_state', { limit: 3, offset: 4 }));
+      expect(parsed.data.items).toHaveLength(2);
+      expect(parsed.data.offset).toBe(4);
+      expect(parsed.data.hasMore).toBe(false);
+    });
+
+    it('returns error result on invalid offset', async () => {
+      const parsed = parse(await mcp.callTool('get_flow_state', { offset: -1 }));
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toMatch(/Invalid offset/);
+    });
+  });
+});

--- a/src/server/pagination-integration.test.ts
+++ b/src/server/pagination-integration.test.ts
@@ -159,7 +159,7 @@ describe('Pagination + filters', () => {
     it('combines filter + sort + pagination deterministically', async () => {
       const parsed = parse(
         await mcp.callTool('get_flows', {
-          labelContains: 'a',
+          labelContains: 'l',
           sortBy: 'label',
           order: 'asc',
           limit: 1,

--- a/src/server/pagination.test.ts
+++ b/src/server/pagination.test.ts
@@ -132,11 +132,7 @@ describe('pagination helpers', () => {
     });
 
     it('pushes undefined keys to the end', () => {
-      const mixed = [
-        { id: 'a', score: 5 },
-        { id: 'b' } as any,
-        { id: 'c', score: 1 },
-      ];
+      const mixed = [{ id: 'a', score: 5 }, { id: 'b' } as any, { id: 'c', score: 1 }];
       const out = stableSortBy(mixed, x => x.score, 'asc');
       expect(out.map(x => x.id)).toEqual(['c', 'a', 'b']);
     });

--- a/src/server/pagination.test.ts
+++ b/src/server/pagination.test.ts
@@ -137,7 +137,7 @@ describe('pagination helpers', () => {
         { id: 'b' } as any,
         { id: 'c', score: 1 },
       ];
-      const out = stableSortBy(mixed, x => (x as any).score, 'asc');
+      const out = stableSortBy(mixed, x => x.score, 'asc');
       expect(out.map(x => x.id)).toEqual(['c', 'a', 'b']);
     });
 

--- a/src/server/pagination.test.ts
+++ b/src/server/pagination.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  DEFAULT_LIMIT,
+  MAX_LIMIT,
+  applyPagination,
+  isPaginated,
+  parsePagination,
+  stableSortBy,
+} from './pagination.js';
+
+describe('pagination helpers', () => {
+  describe('isPaginated', () => {
+    it('returns false for null/undefined args', () => {
+      expect(isPaginated(undefined)).toBe(false);
+      expect(isPaginated(null)).toBe(false);
+    });
+
+    it('returns false when neither limit nor offset is provided', () => {
+      expect(isPaginated({})).toBe(false);
+      expect(isPaginated({ query: 'foo' })).toBe(false);
+    });
+
+    it('returns true when limit is provided', () => {
+      expect(isPaginated({ limit: 10 })).toBe(true);
+    });
+
+    it('returns true when offset is provided', () => {
+      expect(isPaginated({ offset: 0 })).toBe(true);
+    });
+
+    it('returns true when both are provided', () => {
+      expect(isPaginated({ limit: 10, offset: 5 })).toBe(true);
+    });
+  });
+
+  describe('parsePagination', () => {
+    it('applies defaults when nothing is provided', () => {
+      expect(parsePagination(undefined)).toEqual({ limit: DEFAULT_LIMIT, offset: 0 });
+      expect(parsePagination({})).toEqual({ limit: DEFAULT_LIMIT, offset: 0 });
+    });
+
+    it('uses provided limit and offset', () => {
+      expect(parsePagination({ limit: 25, offset: 75 })).toEqual({ limit: 25, offset: 75 });
+    });
+
+    it('throws when limit is non-integer, < 1, or > MAX_LIMIT', () => {
+      expect(() => parsePagination({ limit: 0 })).toThrow(/Invalid limit/);
+      expect(() => parsePagination({ limit: -1 })).toThrow(/Invalid limit/);
+      expect(() => parsePagination({ limit: 1.5 })).toThrow(/Invalid limit/);
+      expect(() => parsePagination({ limit: MAX_LIMIT + 1 })).toThrow(/Invalid limit/);
+    });
+
+    it('throws when offset is non-integer or negative', () => {
+      expect(() => parsePagination({ offset: -1 })).toThrow(/Invalid offset/);
+      expect(() => parsePagination({ offset: 1.5 })).toThrow(/Invalid offset/);
+    });
+
+    it('accepts boundary values', () => {
+      expect(parsePagination({ limit: 1 })).toEqual({ limit: 1, offset: 0 });
+      expect(parsePagination({ limit: MAX_LIMIT })).toEqual({ limit: MAX_LIMIT, offset: 0 });
+      expect(parsePagination({ offset: 0 })).toEqual({ limit: DEFAULT_LIMIT, offset: 0 });
+    });
+  });
+
+  describe('applyPagination', () => {
+    const items = Array.from({ length: 12 }, (_, i) => ({ id: `item-${i}` }));
+
+    it('slices items per limit/offset and reports total', () => {
+      const env = applyPagination(items, { limit: 5, offset: 0 });
+      expect(env.items).toHaveLength(5);
+      expect(env.items[0]).toEqual({ id: 'item-0' });
+      expect(env.total).toBe(12);
+      expect(env.limit).toBe(5);
+      expect(env.offset).toBe(0);
+      expect(env.hasMore).toBe(true);
+    });
+
+    it('sets hasMore false on the last page', () => {
+      const env = applyPagination(items, { limit: 5, offset: 10 });
+      expect(env.items).toHaveLength(2);
+      expect(env.hasMore).toBe(false);
+    });
+
+    it('returns empty slice when offset is beyond end', () => {
+      const env = applyPagination(items, { limit: 5, offset: 100 });
+      expect(env.items).toEqual([]);
+      expect(env.hasMore).toBe(false);
+      expect(env.total).toBe(12);
+    });
+
+    it('uses defaults when args omit pagination fields', () => {
+      const env = applyPagination(items, undefined);
+      expect(env.limit).toBe(DEFAULT_LIMIT);
+      expect(env.offset).toBe(0);
+      expect(env.items).toHaveLength(12);
+      expect(env.hasMore).toBe(false);
+    });
+
+    it('handles empty input', () => {
+      const env = applyPagination<{ id: string }>([], { limit: 10 });
+      expect(env).toEqual({ items: [], total: 0, limit: 10, offset: 0, hasMore: false });
+    });
+
+    it('propagates parsePagination errors', () => {
+      expect(() => applyPagination(items, { limit: 0 })).toThrow(/Invalid limit/);
+    });
+  });
+
+  describe('stableSortBy', () => {
+    const data = [
+      { id: 'c', score: 1 },
+      { id: 'a', score: 2 },
+      { id: 'b', score: 2 },
+      { id: 'd', score: 0 },
+    ];
+
+    it('sorts ascending by key', () => {
+      const out = stableSortBy(data, x => x.score, 'asc');
+      expect(out.map(x => x.score)).toEqual([0, 1, 2, 2]);
+    });
+
+    it('sorts descending by key', () => {
+      const out = stableSortBy(data, x => x.score, 'desc');
+      expect(out.map(x => x.score)).toEqual([2, 2, 1, 0]);
+    });
+
+    it('falls back to id when primary key is equal', () => {
+      const out = stableSortBy(data, x => x.score, 'asc');
+      const equalGroup = out.filter(x => x.score === 2);
+      expect(equalGroup.map(x => x.id)).toEqual(['a', 'b']);
+    });
+
+    it('pushes undefined keys to the end', () => {
+      const mixed = [
+        { id: 'a', score: 5 },
+        { id: 'b' } as any,
+        { id: 'c', score: 1 },
+      ];
+      const out = stableSortBy(mixed, x => (x as any).score, 'asc');
+      expect(out.map(x => x.id)).toEqual(['c', 'a', 'b']);
+    });
+
+    it('does not mutate the input', () => {
+      const original = [...data];
+      stableSortBy(data, x => x.score, 'asc');
+      expect(data).toEqual(original);
+    });
+  });
+});

--- a/src/server/pagination.ts
+++ b/src/server/pagination.ts
@@ -1,0 +1,95 @@
+/**
+ * Offset-based pagination helpers for paginatable MCP tools.
+ *
+ * Contract:
+ * - Envelope `{ items, total, limit, offset, hasMore }` is returned only when
+ *   a pagination param (limit or offset) is provided. Otherwise the tool keeps
+ *   its legacy response shape — see `isPaginated`.
+ * - Invalid params throw → handled by the tool's catch → surfaced as an MCP
+ *   error result, not a 500.
+ * - Sorts are stabilised by a secondary key (id) so paginated slices are
+ *   deterministic across requests.
+ */
+
+export const DEFAULT_LIMIT = 50;
+export const MAX_LIMIT = 500;
+
+export interface PaginationArgs {
+  limit?: number;
+  offset?: number;
+}
+
+export interface PaginationEnvelope<T> {
+  items: T[];
+  total: number;
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+}
+
+export type SortOrder = 'asc' | 'desc';
+
+export function isPaginated(args: Record<string, unknown> | undefined | null): boolean {
+  if (!args) return false;
+  return args.limit !== undefined || args.offset !== undefined;
+}
+
+export function parsePagination(args: PaginationArgs | undefined | null): {
+  limit: number;
+  offset: number;
+} {
+  const limit = args?.limit;
+  const offset = args?.offset;
+
+  if (limit !== undefined && (!Number.isInteger(limit) || limit < 1 || limit > MAX_LIMIT)) {
+    throw new Error(`Invalid limit: must be an integer between 1 and ${MAX_LIMIT}`);
+  }
+  if (offset !== undefined && (!Number.isInteger(offset) || offset < 0)) {
+    throw new Error('Invalid offset: must be a non-negative integer');
+  }
+
+  return {
+    limit: limit ?? DEFAULT_LIMIT,
+    offset: offset ?? 0,
+  };
+}
+
+export function applyPagination<T>(
+  items: T[],
+  args: PaginationArgs | undefined | null
+): PaginationEnvelope<T> {
+  const { limit, offset } = parsePagination(args);
+  const total = items.length;
+  const slice = items.slice(offset, offset + limit);
+  return {
+    items: slice,
+    total,
+    limit,
+    offset,
+    hasMore: offset + slice.length < total,
+  };
+}
+
+/**
+ * Stable sort: when the primary key compares equal, falls back to comparing
+ * `id` so slice boundaries don't shuffle between requests.
+ */
+export function stableSortBy<T extends { id?: string }>(
+  items: T[],
+  keyFn: (item: T) => string | number | boolean | undefined,
+  order: SortOrder = 'asc'
+): T[] {
+  const mul = order === 'asc' ? 1 : -1;
+  return [...items].sort((a, b) => {
+    const av = keyFn(a);
+    const bv = keyFn(b);
+    if (av === bv) {
+      const aid = a.id ?? '';
+      const bid = b.id ?? '';
+      return aid < bid ? -1 : aid > bid ? 1 : 0;
+    }
+    if (av === undefined) return 1;
+    if (bv === undefined) return -1;
+    return av < bv ? -1 * mul : av > bv ? 1 * mul : 0;
+  });
+}

--- a/src/server/pagination.ts
+++ b/src/server/pagination.ts
@@ -29,6 +29,29 @@ export interface PaginationEnvelope<T> {
 
 export type SortOrder = 'asc' | 'desc';
 
+export function caseInsensitiveIncludes(value: unknown, needle: string): boolean {
+  if (typeof value !== 'string') return false;
+  return value.toLowerCase().includes(needle.toLowerCase());
+}
+
+export function parseSort<K extends string>(
+  args: { sortBy?: unknown; order?: unknown } | undefined | null,
+  allowedKeys: readonly K[]
+): { sortBy: K | undefined; order: SortOrder } {
+  const sortBy = args?.sortBy;
+  const order = args?.order;
+  if (sortBy !== undefined && !allowedKeys.includes(sortBy as K)) {
+    throw new Error(`Invalid sortBy: must be one of ${allowedKeys.join(', ')}`);
+  }
+  if (order !== undefined && order !== 'asc' && order !== 'desc') {
+    throw new Error('Invalid order: must be "asc" or "desc"');
+  }
+  return {
+    sortBy: sortBy === undefined ? undefined : (sortBy as K),
+    order: order === undefined ? 'asc' : order,
+  };
+}
+
 export function isPaginated(args: Record<string, unknown> | undefined | null): boolean {
   if (!args) return false;
   return args.limit !== undefined || args.offset !== undefined;

--- a/src/server/pagination.ts
+++ b/src/server/pagination.ts
@@ -71,8 +71,8 @@ export function applyPagination<T>(
 }
 
 /**
- * Stable sort: when the primary key compares equal, falls back to comparing
- * `id` so slice boundaries don't shuffle between requests.
+ * Stable sort with id as secondary key. Uses a Schwartzian transform so
+ * keyFn is invoked once per item rather than ~2·n·log n times during sort.
  */
 export function stableSortBy<T extends { id?: string }>(
   items: T[],
@@ -80,16 +80,18 @@ export function stableSortBy<T extends { id?: string }>(
   order: SortOrder = 'asc'
 ): T[] {
   const mul = order === 'asc' ? 1 : -1;
-  return [...items].sort((a, b) => {
-    const av = keyFn(a);
-    const bv = keyFn(b);
-    if (av === bv) {
-      const aid = a.id ?? '';
-      const bid = b.id ?? '';
-      return aid < bid ? -1 : aid > bid ? 1 : 0;
+  const tagged = items.map(item => ({ item, key: keyFn(item) }));
+  tagged.sort((a, b) => {
+    if (a.key === undefined && b.key !== undefined) return 1;
+    if (b.key === undefined && a.key !== undefined) return -1;
+    if (a.key !== b.key) {
+      // Both defined and unequal — primary comparison.
+      return (a.key as any) < (b.key as any) ? -mul : mul;
     }
-    if (av === undefined) return 1;
-    if (bv === undefined) return -1;
-    return av < bv ? -1 * mul : av > bv ? 1 * mul : 0;
+    // Primary keys equal (or both undefined) — fall back to id.
+    const aid = a.item.id ?? '';
+    const bid = b.item.id ?? '';
+    return aid < bid ? -1 : aid > bid ? 1 : 0;
   });
+  return tagged.map(t => t.item);
 }

--- a/src/server/pagination.ts
+++ b/src/server/pagination.ts
@@ -82,13 +82,15 @@ export function stableSortBy<T extends { id?: string }>(
   const mul = order === 'asc' ? 1 : -1;
   const tagged = items.map(item => ({ item, key: keyFn(item) }));
   tagged.sort((a, b) => {
-    if (a.key === undefined && b.key !== undefined) return 1;
-    if (b.key === undefined && a.key !== undefined) return -1;
-    if (a.key !== b.key) {
-      // Both defined and unequal — primary comparison.
-      return (a.key as any) < (b.key as any) ? -mul : mul;
+    const ak = a.key;
+    const bk = b.key;
+    if (ak !== bk) {
+      // Primary keys differ — undefined sorts last, otherwise compare.
+      if (ak === undefined) return 1;
+      if (bk === undefined) return -1;
+      return (ak as any) < (bk as any) ? -mul : mul;
     }
-    // Primary keys equal (or both undefined) — fall back to id.
+    // Primary keys equal (or both undefined) — fall back to id for stability.
     const aid = a.item.id ?? '';
     const bid = b.item.id ?? '';
     return aid < bid ? -1 : aid > bid ? 1 : 0;


### PR DESCRIPTION
## Summary

Implements **Feature 5** of the MCP v3.0 roadmap: opt-in pagination + enriched filtering on the 4 list-shaped MCP tools.

### Tools updated

| Tool | New parameters | Legacy shape preserved? |
|------|----------------|--------------------------|
| `get_flows` | `limit`, `offset`, `sortBy` (`label`/`nodeCount`/`disabled`), `order`, `disabled`, `labelContains` | ✅ Plain array when no `limit`/`offset` |
| `search_flows` | `limit`, `offset`, `nodeTypePrefix`, `excludeFlowIds` | ✅ `{ matches, total }` + internal 10-cap when no `limit`/`offset` |
| `get_installed_modules` | `limit`, `offset`, `query` | ✅ Raw JSON dump when no `limit`/`offset`/`query` |
| `get_flow_state` | `limit`, `offset` | ✅ Raw status object when no `limit`/`offset` |

### Contract

- Envelope `{ items, total, limit, offset, hasMore }` is returned **only** when pagination params are passed — every other call returns the exact legacy shape it always did.
- Defaults: `limit = 50`, max `limit = 500`, `offset = 0`.
- Sorts use a secondary id key so slice boundaries are stable across requests.
- Invalid `limit`/`offset`/`sortBy`/`order` → `{ success: false, error: ... }` (not a 500).

### Files

- `src/server/pagination.ts` — helper module (`isPaginated`, `parsePagination`, `applyPagination`, `stableSortBy`).
- `src/server/mcp-server.ts` — tool schemas + callTool cases updated.
- `src/server/pagination.test.ts` — unit tests for the helper.
- `src/server/pagination-integration.test.ts` — integration tests for the 4 tools, including legacy-shape preservation.

### Roadmap

Feature 5 of [[nodered-feature-backlog]] — order: 1 → **5** → 2 → 4 → 3.

## Test plan

- [ ] CI green on `feature/pagination-filters`
- [ ] All existing `mcp-server.test.ts` cases still pass (legacy shapes preserved)
- [ ] `pagination.test.ts` + `pagination-integration.test.ts` pass
- [ ] `/simplify` review run before merge
- [ ] Production verification after merge: call `get_flows` with `{ limit: 5 }` against live MCP, confirm envelope shape