### PR TITLE
feat: MCP Elicitation — clarifying questions mid-call for missing params

### DIFF
--- a/src/server/mcp-server.test.ts
+++ b/src/server/mcp-server.test.ts
@@ -91,6 +91,7 @@ vi.mock('@modelcontextprotocol/sdk/server/index.js', () => {
         this.handlers.set(schema, handler);
       });
       connect = vi.fn();
+      elicitInput = vi.fn();
     },
   };
 });
@@ -1206,6 +1207,77 @@ describe('McpNodeRedServer', () => {
 
       expect(result.description).toBeDefined();
       expect(result.messages).toBeDefined();
+    });
+  });
+
+  describe('Elicitation', () => {
+    let serverInstance: any;
+
+    beforeEach(() => {
+      serverInstance = mcpServer.getServer();
+      serverInstance.elicitInput = vi.fn();
+    });
+
+    it('should elicit flowId for get_flow when not provided and use it', async () => {
+      serverInstance.elicitInput.mockResolvedValueOnce({ action: 'accept', content: { flowId: 'flow-1' } });
+      const result = await mcpServer.callTool('get_flow', {});
+      expect(mockNodeRedClient.getFlow).toHaveBeenCalledWith('flow-1');
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.success).toBe(true);
+    });
+
+    it('should return error when flowId elicitation is declined', async () => {
+      serverInstance.elicitInput.mockResolvedValueOnce({ action: 'decline', content: null });
+      const result = await mcpServer.callTool('get_flow', {});
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain('flowId');
+    });
+
+    it('should fall back to error when elicitInput throws (no active session)', async () => {
+      serverInstance.elicitInput.mockRejectedValueOnce(new Error('No active session'));
+      const result = await mcpServer.callTool('get_flow', {});
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain('flowId');
+    });
+
+    it('should not call elicitInput when flowId is already provided', async () => {
+      const result = await mcpServer.callTool('get_flow', { flowId: 'flow-1' });
+      expect(serverInstance.elicitInput).not.toHaveBeenCalled();
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.success).toBe(true);
+    });
+
+    it('should elicit flowId for enable_flow and enable the flow', async () => {
+      serverInstance.elicitInput.mockResolvedValueOnce({ action: 'accept', content: { flowId: 'flow-1' } });
+      const result = await mcpServer.callTool('enable_flow', {});
+      expect(mockNodeRedClient.enableFlow).toHaveBeenCalledWith('flow-1');
+      expect(result.content[0].text).toContain('enabled');
+    });
+
+    it('should elicit confirmation for delete_flow when dryRun:false and confirm is missing', async () => {
+      serverInstance.elicitInput.mockResolvedValueOnce({ action: 'accept', content: { confirmed: true } });
+      const result = await mcpServer.callTool('delete_flow', { flowId: 'flow-1', dryRun: false });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.deleted).toBeDefined();
+      expect(mockNodeRedClient.deleteFlow).toHaveBeenCalledWith('flow-1');
+    });
+
+    it('should block deletion when confirmation elicitation is declined', async () => {
+      serverInstance.elicitInput.mockResolvedValueOnce({ action: 'accept', content: { confirmed: false } });
+      const result = await mcpServer.callTool('delete_flow', { flowId: 'flow-1', dryRun: false });
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain('confirm');
+      expect(mockNodeRedClient.deleteFlow).not.toHaveBeenCalled();
+    });
+
+    it('should elicit search query for search_modules when not provided', async () => {
+      serverInstance.elicitInput.mockResolvedValueOnce({ action: 'accept', content: { query: 'mqtt' } });
+      await mcpServer.callTool('search_modules', {});
+      expect(mockNodeRedClient.searchModules).toHaveBeenCalledWith('mqtt', 'all', 10);
     });
   });
 });

--- a/src/server/mcp-server.test.ts
+++ b/src/server/mcp-server.test.ts
@@ -1215,7 +1215,6 @@ describe('McpNodeRedServer', () => {
 
     beforeEach(() => {
       serverInstance = mcpServer.getServer();
-      serverInstance.elicitInput = vi.fn();
     });
 
     it('should elicit flowId for get_flow when not provided and use it', async () => {

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -190,7 +190,8 @@ export class McpNodeRedServer {
           resources: this.config.capabilities.resources ? {} : undefined,
           prompts: this.config.capabilities.prompts ? {} : undefined,
           logging: this.config.capabilities.logging ? {} : undefined,
-        },
+          elicitation: {},
+        } as any,
       }
     );
 
@@ -234,6 +235,73 @@ export class McpNodeRedServer {
       const rendered = await this.getPrompt(name, args || {});
       return { description: rendered.description, messages: rendered.messages };
     });
+  }
+
+  private async tryElicitString(
+    message: string,
+    title: string,
+    field: string
+  ): Promise<string | null> {
+    try {
+      const res = await (this.server as any).elicitInput({
+        mode: 'form',
+        message,
+        requestedSchema: {
+          type: 'object',
+          properties: {
+            [field]: { type: 'string', title },
+          },
+          required: [field],
+        },
+      });
+      if (res?.action === 'accept' && res.content?.[field]) {
+        return String(res.content[field]);
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async tryElicitFlowId(verb: string): Promise<string | null> {
+    let list = '';
+    try {
+      const flows = await this.nodeRedClient.getFlowSummaries(['tab', 'subflow']);
+      list = `\n\nAvailable flows:\n${flows
+        .slice(0, 15)
+        .map((f: any) => `• ${f.label || '(no label)'} — ${f.id}`)
+        .join('\n')}`;
+    } catch {
+      // getFlowSummaries failed — proceed without list
+    }
+    return this.tryElicitString(
+      `Which flow do you want to ${verb}?${list}`,
+      'Flow ID',
+      'flowId'
+    );
+  }
+
+  private async tryElicitConfirm(message: string): Promise<boolean> {
+    try {
+      const res = await (this.server as any).elicitInput({
+        mode: 'form',
+        message,
+        requestedSchema: {
+          type: 'object',
+          properties: {
+            confirmed: {
+              type: 'boolean',
+              title: 'Confirm',
+              description: 'Set to true to proceed, false to cancel',
+            },
+          },
+          required: ['confirmed'],
+        },
+      });
+      return res?.action === 'accept' && res.content?.confirmed === true;
+    } catch {
+      return false;
+    }
   }
 
   /**
@@ -686,18 +754,17 @@ export class McpNodeRedServer {
           break;
         }
 
-        case 'get_flow':
-          validateRequired(args, ['flowId']);
-          result = {
-            success: true,
-            data: await this.nodeRedClient.getFlow(args.flowId),
-            timestamp,
-          };
+        case 'get_flow': {
+          const flowId = args?.flowId ?? (await this.tryElicitFlowId('get'));
+          if (!flowId) throw new Error('Missing required parameter: flowId');
+          result = { success: true, data: await this.nodeRedClient.getFlow(flowId), timestamp };
           break;
+        }
 
         case 'validate_flow': {
-          validateRequired(args, ['flowId']);
-          const flow = await this.nodeRedClient.getFlow(args.flowId);
+          const flowId = args?.flowId ?? (await this.tryElicitFlowId('validate'));
+          if (!flowId) throw new Error('Missing required parameter: flowId');
+          const flow = await this.nodeRedClient.getFlow(flowId);
           result = { success: true, data: validateFlowData(flow), timestamp };
           break;
         }
@@ -715,61 +782,47 @@ export class McpNodeRedServer {
             ],
           };
 
-        case 'update_flow':
-          validateRequired(args, ['flowId', 'flowData']);
+        case 'update_flow': {
+          const flowId = args?.flowId ?? (await this.tryElicitFlowId('update'));
+          if (!flowId) throw new Error('Missing required parameter: flowId');
+          if (!args?.flowData) throw new Error('Missing required parameter: flowData');
           if (args?.validate) validateFlowOrThrow(args.flowData);
-          await this.nodeRedClient.updateFlow(args.flowId, args.flowData);
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Flow ${args.flowId} updated successfully`,
-              },
-            ],
-          };
+          await this.nodeRedClient.updateFlow(flowId, args.flowData);
+          return { content: [{ type: 'text', text: `Flow ${flowId} updated successfully` }] };
+        }
 
-        case 'enable_flow':
-          validateRequired(args, ['flowId']);
-          await this.nodeRedClient.enableFlow(args.flowId);
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Flow ${args.flowId} enabled`,
-              },
-            ],
-          };
+        case 'enable_flow': {
+          const flowId = args?.flowId ?? (await this.tryElicitFlowId('enable'));
+          if (!flowId) throw new Error('Missing required parameter: flowId');
+          await this.nodeRedClient.enableFlow(flowId);
+          return { content: [{ type: 'text', text: `Flow ${flowId} enabled` }] };
+        }
 
-        case 'disable_flow':
-          validateRequired(args, ['flowId']);
-          await this.nodeRedClient.disableFlow(args.flowId);
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Flow ${args.flowId} disabled`,
-              },
-            ],
-          };
+        case 'disable_flow': {
+          const flowId = args?.flowId ?? (await this.tryElicitFlowId('disable'));
+          if (!flowId) throw new Error('Missing required parameter: flowId');
+          await this.nodeRedClient.disableFlow(flowId);
+          return { content: [{ type: 'text', text: `Flow ${flowId} disabled` }] };
+        }
 
-        case 'search_modules':
-          validateRequired(args, ['query']);
-          const searchQuery = args.query;
-          const searchCategory = args.category || 'all';
-          const searchLimit = args.limit || 10;
+        case 'search_modules': {
+          const query =
+            args?.query ??
+            (await this.tryElicitString(
+              'What would you like to search for in Node-RED modules? (e.g., "mqtt", "dashboard")',
+              'Search query',
+              'query'
+            ));
+          if (!query) throw new Error('Missing required parameter: query');
+          const searchCategory = args?.category || 'all';
+          const searchLimit = args?.limit || 10;
           const searchResults = await this.nodeRedClient.searchModules(
-            searchQuery,
+            query,
             searchCategory,
             searchLimit
           );
-          return {
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify(searchResults, null, 2),
-              },
-            ],
-          };
+          return { content: [{ type: 'text', text: JSON.stringify(searchResults, null, 2) }] };
+        }
 
         case 'install_module':
           validateRequired(args, ['moduleName']);
@@ -847,9 +900,10 @@ export class McpNodeRedServer {
         }
 
         case 'delete_flow': {
-          validateRequired(args, ['flowId']);
+          const flowId = args?.flowId ?? (await this.tryElicitFlowId('delete'));
+          if (!flowId) throw new Error('Missing required parameter: flowId');
           const dryRun = args?.dryRun !== false;
-          const flow = await this.nodeRedClient.getFlow(args.flowId);
+          const flow = await this.nodeRedClient.getFlow(flowId);
           const flowInfo = {
             id: flow.id,
             label: flow.label ?? '',
@@ -861,11 +915,15 @@ export class McpNodeRedServer {
             break;
           }
 
-          if (!args?.confirm) {
-            throw new Error('Deletion requires confirm: true and dryRun: false');
+          let confirmed = Boolean(args?.confirm);
+          if (!confirmed) {
+            confirmed = await this.tryElicitConfirm(
+              `Delete flow "${flowInfo.label || flowId}"? This will permanently remove ${flowInfo.nodeCount} node(s) and cannot be undone.`
+            );
           }
+          if (!confirmed) throw new Error('Deletion requires confirm: true and dryRun: false');
 
-          await this.nodeRedClient.deleteFlow(args.flowId);
+          await this.nodeRedClient.deleteFlow(flowId);
           result = { success: true, data: { deleted: flowInfo }, timestamp };
           break;
         }

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -164,6 +164,7 @@ export class McpNodeRedServer {
         resources: true,
         prompts: true,
         logging: true,
+        elicitation: true,
       },
       nodeRed: {
         url: process.env.NODERED_URL || 'http://localhost:1880',
@@ -190,7 +191,7 @@ export class McpNodeRedServer {
           resources: this.config.capabilities.resources ? {} : undefined,
           prompts: this.config.capabilities.prompts ? {} : undefined,
           logging: this.config.capabilities.logging ? {} : undefined,
-          elicitation: {},
+          elicitation: this.config.capabilities.elicitation !== false ? {} : undefined,
         } as any,
       }
     );
@@ -237,30 +238,26 @@ export class McpNodeRedServer {
     });
   }
 
-  private async tryElicitString(
+  // Raw elicitInput wrapper — single point for the (server as any) cast and try/catch
+  private async tryElicitField<T>(
     message: string,
-    title: string,
-    field: string
-  ): Promise<string | null> {
+    requestedSchema: object,
+    pick: (content: any) => T | null
+  ): Promise<T | null> {
     try {
-      const res = await (this.server as any).elicitInput({
-        mode: 'form',
-        message,
-        requestedSchema: {
-          type: 'object',
-          properties: {
-            [field]: { type: 'string', title },
-          },
-          required: [field],
-        },
-      });
-      if (res?.action === 'accept' && res.content?.[field]) {
-        return String(res.content[field]);
-      }
-      return null;
+      const res = await (this.server as any).elicitInput({ mode: 'form', message, requestedSchema });
+      return res?.action === 'accept' ? pick(res.content) : null;
     } catch {
       return null;
     }
+  }
+
+  private tryElicitString(message: string, title: string, field: string): Promise<string | null> {
+    return this.tryElicitField(
+      message,
+      { type: 'object', properties: { [field]: { type: 'string', title } }, required: [field] },
+      c => (c?.[field] ? String(c[field]) : null)
+    );
   }
 
   private async tryElicitFlowId(verb: string): Promise<string | null> {
@@ -282,11 +279,10 @@ export class McpNodeRedServer {
   }
 
   private async tryElicitConfirm(message: string): Promise<boolean> {
-    try {
-      const res = await (this.server as any).elicitInput({
-        mode: 'form',
+    return (
+      (await this.tryElicitField(
         message,
-        requestedSchema: {
+        {
           type: 'object',
           properties: {
             confirmed: {
@@ -297,11 +293,15 @@ export class McpNodeRedServer {
           },
           required: ['confirmed'],
         },
-      });
-      return res?.action === 'accept' && res.content?.confirmed === true;
-    } catch {
-      return false;
-    }
+        c => (c?.confirmed === true ? true : null)
+      )) ?? false
+    );
+  }
+
+  private async resolveFlowId(args: any, verb: string): Promise<string> {
+    const flowId = args?.flowId ?? (await this.tryElicitFlowId(verb));
+    if (!flowId) throw new Error('Missing required parameter: flowId');
+    return flowId;
   }
 
   /**
@@ -755,15 +755,13 @@ export class McpNodeRedServer {
         }
 
         case 'get_flow': {
-          const flowId = args?.flowId ?? (await this.tryElicitFlowId('get'));
-          if (!flowId) throw new Error('Missing required parameter: flowId');
+          const flowId = await this.resolveFlowId(args, 'get');
           result = { success: true, data: await this.nodeRedClient.getFlow(flowId), timestamp };
           break;
         }
 
         case 'validate_flow': {
-          const flowId = args?.flowId ?? (await this.tryElicitFlowId('validate'));
-          if (!flowId) throw new Error('Missing required parameter: flowId');
+          const flowId = await this.resolveFlowId(args, 'validate');
           const flow = await this.nodeRedClient.getFlow(flowId);
           result = { success: true, data: validateFlowData(flow), timestamp };
           break;
@@ -783,8 +781,7 @@ export class McpNodeRedServer {
           };
 
         case 'update_flow': {
-          const flowId = args?.flowId ?? (await this.tryElicitFlowId('update'));
-          if (!flowId) throw new Error('Missing required parameter: flowId');
+          const flowId = await this.resolveFlowId(args, 'update');
           if (!args?.flowData) throw new Error('Missing required parameter: flowData');
           if (args?.validate) validateFlowOrThrow(args.flowData);
           await this.nodeRedClient.updateFlow(flowId, args.flowData);
@@ -792,15 +789,13 @@ export class McpNodeRedServer {
         }
 
         case 'enable_flow': {
-          const flowId = args?.flowId ?? (await this.tryElicitFlowId('enable'));
-          if (!flowId) throw new Error('Missing required parameter: flowId');
+          const flowId = await this.resolveFlowId(args, 'enable');
           await this.nodeRedClient.enableFlow(flowId);
           return { content: [{ type: 'text', text: `Flow ${flowId} enabled` }] };
         }
 
         case 'disable_flow': {
-          const flowId = args?.flowId ?? (await this.tryElicitFlowId('disable'));
-          if (!flowId) throw new Error('Missing required parameter: flowId');
+          const flowId = await this.resolveFlowId(args, 'disable');
           await this.nodeRedClient.disableFlow(flowId);
           return { content: [{ type: 'text', text: `Flow ${flowId} disabled` }] };
         }
@@ -814,12 +809,10 @@ export class McpNodeRedServer {
               'query'
             ));
           if (!query) throw new Error('Missing required parameter: query');
-          const searchCategory = args?.category || 'all';
-          const searchLimit = args?.limit || 10;
           const searchResults = await this.nodeRedClient.searchModules(
             query,
-            searchCategory,
-            searchLimit
+            args?.category || 'all',
+            args?.limit || 10
           );
           return { content: [{ type: 'text', text: JSON.stringify(searchResults, null, 2) }] };
         }
@@ -900,8 +893,7 @@ export class McpNodeRedServer {
         }
 
         case 'delete_flow': {
-          const flowId = args?.flowId ?? (await this.tryElicitFlowId('delete'));
-          if (!flowId) throw new Error('Missing required parameter: flowId');
+          const flowId = await this.resolveFlowId(args, 'delete');
           const dryRun = args?.dryRun !== false;
           const flow = await this.nodeRedClient.getFlow(flowId);
           const flowInfo = {

--- a/src/types/mcp-extensions.ts
+++ b/src/types/mcp-extensions.ts
@@ -114,6 +114,7 @@ export interface McpServerConfig {
     resources?: boolean;
     prompts?: boolean;
     logging?: boolean;
+    elicitation?: boolean;
   };
   nodeRed: {
     url: string;


### PR DESCRIPTION
## Summary

Adds MCP Elicitation support — when a client omits a required parameter, the server asks for it interactively via `server.elicitInput()` instead of immediately throwing an error.

### What changed

**`src/server/mcp-server.ts`**
- Declares `elicitation: {}` in server capabilities (with `as any` cast for SDK v1.29.0 type compatibility)
- Adds three private helpers:
  - `tryElicitString(message, title, field)` — elicits a single string field
  - `tryElicitFlowId(verb)` — elicits a flow ID, prepending a live list of available flows
  - `tryElicitConfirm(message)` — elicits a boolean confirmation
- 7 tools now elicit missing inputs instead of failing immediately:
  - `get_flow`, `validate_flow`, `update_flow`, `enable_flow`, `disable_flow` — elicit `flowId`
  - `delete_flow` — elicits `flowId` if missing; elicits confirmation when `dryRun:false` and `confirm` not supplied
  - `search_modules` — elicits `query`

**`src/server/mcp-server.test.ts`**
- Adds `elicitInput = vi.fn()` to the Server mock class
- New `describe('Elicitation')` block with 8 tests covering: accept/decline/throw paths, no-elicitation-when-param-present, and delete confirmation flow

### Graceful degradation

All elicitation calls are wrapped in try/catch. When called via the HTTP API (no active MCP session), `elicitInput` throws → helpers return `null`/`false` → tools fall back to their normal "missing required parameter" error. No special HTTP-path handling needed.

### CI note

`Code Quality & Security` fails on pre-existing TypeScript errors in `express-app.ts` lines 1031/1108 (present on `main` before this PR). All test suites pass.
