### PR TITLE
feat: add get_node_errors tool

### DIFF
--- a/src/server/mcp-server.test.ts
+++ b/src/server/mcp-server.test.ts
@@ -99,6 +99,18 @@ vi.mock('../services/embedding-provider.js', () => ({
   createEmbeddingProvider: vi.fn().mockReturnValue({}),
 }));
 
+const mockNodeErrorChecker = {
+  check: vi.fn(),
+};
+
+vi.mock('../services/node-error-checker.js', () => ({
+  NodeErrorChecker: class {
+    constructor() {
+      return mockNodeErrorChecker;
+    }
+  },
+}));
+
 // Mock MCP SDK Server
 vi.mock('@modelcontextprotocol/sdk/server/index.js', () => {
   return {
@@ -324,9 +336,9 @@ describe('McpNodeRedServer', () => {
       expect(tool?.annotations?.readOnlyHint).toBe(true);
     });
 
-    it('should have exactly 19 tools defined', () => {
+    it('should have exactly 20 tools defined', () => {
       const tools = mcpServer.getToolDefinitions();
-      expect(tools.length).toBe(19);
+      expect(tools.length).toBe(20);
     });
 
     it('should include semantic_search_flows tool', () => {
@@ -338,6 +350,15 @@ describe('McpNodeRedServer', () => {
       expect(tool?.inputSchema.properties).toHaveProperty('scope');
       expect(tool?.inputSchema.properties).toHaveProperty('topK');
       expect(tool?.inputSchema.properties).toHaveProperty('refresh');
+    });
+
+    it('should include get_node_errors tool', () => {
+      const tools = mcpServer.getToolDefinitions();
+      const tool = tools.find(t => t.name === 'get_node_errors');
+      expect(tool).toBeDefined();
+      expect(tool?.annotations?.readOnlyHint).toBe(true);
+      expect(tool?.inputSchema.properties).toHaveProperty('includeWarnings');
+      expect(tool?.inputSchema.properties).toHaveProperty('timeoutMs');
     });
   });
 
@@ -1381,6 +1402,53 @@ describe('McpNodeRedServer', () => {
       mockSemanticIndex.search.mockResolvedValueOnce([]);
       await mcpServer.callTool('semantic_search_flows', {});
       expect(mockSemanticIndex.search).toHaveBeenCalledWith('temperature automation', 10, 'all');
+    });
+  });
+
+  describe('Tool Execution - get_node_errors', () => {
+    const mockResult = {
+      errors: [
+        {
+          nodeId: 'n1',
+          nodeType: 'mqtt in',
+          label: 'Listen',
+          status: { fill: 'red', text: 'not connected' },
+          flowId: 'flow-1',
+          flowName: 'My Flow',
+        },
+      ],
+      warnings: [],
+      statusesMayBeIncomplete: false,
+    };
+
+    it('should return error check results', async () => {
+      mockNodeErrorChecker.check.mockResolvedValueOnce(mockResult);
+      const result = await mcpServer.callTool('get_node_errors', {});
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(mockNodeErrorChecker.check).toHaveBeenCalledWith({
+        includeWarnings: false,
+        timeoutMs: undefined,
+      });
+      expect(parsed.success).toBe(true);
+      expect(parsed.data).toEqual(mockResult);
+    });
+
+    it('should pass includeWarnings and timeoutMs to checker', async () => {
+      mockNodeErrorChecker.check.mockResolvedValueOnce({ errors: [], warnings: [], statusesMayBeIncomplete: false });
+      await mcpServer.callTool('get_node_errors', { includeWarnings: true, timeoutMs: 5000 });
+      expect(mockNodeErrorChecker.check).toHaveBeenCalledWith({
+        includeWarnings: true,
+        timeoutMs: 5000,
+      });
+    });
+
+    it('should return error result when checker throws', async () => {
+      mockNodeErrorChecker.check.mockRejectedValueOnce(new Error('auth failed'));
+      const result = await mcpServer.callTool('get_node_errors', {});
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain('auth failed');
     });
   });
 });

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -14,6 +14,7 @@ import {
 
 import { promptRegistry } from '../prompts/index.js';
 import { createEmbeddingProvider } from '../services/embedding-provider.js';
+import { NodeErrorChecker } from '../services/node-error-checker.js';
 import { NodeRedAPIClient } from '../services/nodered-api.js';
 import { SemanticFlowIndex } from '../services/semantic-index.js';
 import {
@@ -715,6 +716,31 @@ export class McpNodeRedServer {
         inputSchema: { type: 'object', properties: {}, required: [] },
       },
       {
+        name: 'get_node_errors',
+        description:
+          'Check Node-RED for nodes that are in an error state (red status) after deployment. Connects to the Node-RED event bus, collects retained node statuses, and returns any nodes with active errors or warnings. Use after create_flow or update_flow to catch nodes with missing required configuration.',
+        annotations: { readOnlyHint: true },
+        inputSchema: {
+          type: 'object',
+          properties: {
+            includeWarnings: {
+              type: 'boolean',
+              description: 'Also return nodes with yellow (warning) status (default: false)',
+              default: false,
+            },
+            timeoutMs: {
+              type: 'number',
+              description:
+                'How long to collect statuses from the event bus in milliseconds (default: 2000, max: 30000)',
+              default: 2000,
+              minimum: 100,
+              maximum: 30000,
+            },
+          },
+          required: [],
+        },
+      },
+      {
         name: 'semantic_search_flows',
         description:
           'Search Node-RED flows and nodes using semantic similarity (BM25 by default; set EMBEDDING_API_URL for vector search). Returns ranked results with scores.',
@@ -1061,6 +1087,16 @@ export class McpNodeRedServer {
 
         case 'get_runtime_info': {
           result = { success: true, data: await this.nodeRedClient.getRuntimeInfo(), timestamp };
+          break;
+        }
+
+        case 'get_node_errors': {
+          const checker = new NodeErrorChecker(this.nodeRedClient);
+          const data = await checker.check({
+            includeWarnings: args?.includeWarnings ?? false,
+            timeoutMs: args?.timeoutMs,
+          });
+          result = { success: true, data, timestamp };
           break;
         }
 

--- a/src/services/node-error-checker.test.ts
+++ b/src/services/node-error-checker.test.ts
@@ -15,19 +15,19 @@ vi.mock('../utils/auth.js', () => ({
 
 vi.mock('./nodered-api.js', () => ({
   NodeRedAPIClient: vi.fn().mockImplementation(() => ({
-    getBaseURL: vi.fn().mockReturnValue('http://localhost:0'),
+    getCommsWsUrl: vi.fn().mockReturnValue('ws://localhost:0/comms'),
     getFlows: vi.fn().mockResolvedValue([]),
   })),
 }));
 
 interface FakeClient {
-  getBaseURL: ReturnType<typeof vi.fn>;
+  getCommsWsUrl: ReturnType<typeof vi.fn>;
   getFlows: ReturnType<typeof vi.fn>;
 }
 
 function makeClient(overrides: Partial<FakeClient> = {}): NodeRedAPIClient {
   const defaults: FakeClient = {
-    getBaseURL: vi.fn().mockReturnValue('http://localhost:0'),
+    getCommsWsUrl: vi.fn().mockReturnValue('ws://localhost:0/comms'),
     getFlows: vi.fn().mockResolvedValue([]),
   };
   return { ...defaults, ...overrides } as unknown as NodeRedAPIClient;
@@ -63,14 +63,14 @@ describe('NodeErrorChecker', () => {
 
   it('returns empty errors when no status messages arrive within timeout', async () => {
     const { wss, port, close } = await startWss();
-    const client = makeClient({ getBaseURL: vi.fn().mockReturnValue(`http://localhost:${port}`) });
+    const client = makeClient({ getCommsWsUrl: vi.fn().mockReturnValue(`ws://localhost:${port}/comms`) });
     const checker = new NodeErrorChecker(client);
 
     const result = await checker.check({ timeoutMs: 100 });
 
     expect(result.errors).toEqual([]);
     expect(result.warnings).toEqual([]);
-    expect(result.statusesMayBeIncomplete).toBe(true);
+    expect(result.statusesMayBeIncomplete).toBe(false);
 
     wss.close();
     await close();
@@ -78,7 +78,7 @@ describe('NodeErrorChecker', () => {
 
   it('returns a red node in errors', async () => {
     const { wss, port, close } = await startWss();
-    const client = makeClient({ getBaseURL: vi.fn().mockReturnValue(`http://localhost:${port}`) });
+    const client = makeClient({ getCommsWsUrl: vi.fn().mockReturnValue(`ws://localhost:${port}/comms`) });
     const checker = new NodeErrorChecker(client);
 
     wss.on('connection', ws => {
@@ -98,7 +98,7 @@ describe('NodeErrorChecker', () => {
 
   it('deduplicates: red then green → not in errors', async () => {
     const { wss, port, close } = await startWss();
-    const client = makeClient({ getBaseURL: vi.fn().mockReturnValue(`http://localhost:${port}`) });
+    const client = makeClient({ getCommsWsUrl: vi.fn().mockReturnValue(`ws://localhost:${port}/comms`) });
     const checker = new NodeErrorChecker(client);
 
     wss.on('connection', ws => {
@@ -117,7 +117,7 @@ describe('NodeErrorChecker', () => {
 
   it('does not include yellow nodes when includeWarnings is false', async () => {
     const { wss, port, close } = await startWss();
-    const client = makeClient({ getBaseURL: vi.fn().mockReturnValue(`http://localhost:${port}`) });
+    const client = makeClient({ getCommsWsUrl: vi.fn().mockReturnValue(`ws://localhost:${port}/comms`) });
     const checker = new NodeErrorChecker(client);
 
     wss.on('connection', ws => {
@@ -134,7 +134,7 @@ describe('NodeErrorChecker', () => {
 
   it('includes yellow nodes when includeWarnings is true', async () => {
     const { wss, port, close } = await startWss();
-    const client = makeClient({ getBaseURL: vi.fn().mockReturnValue(`http://localhost:${port}`) });
+    const client = makeClient({ getCommsWsUrl: vi.fn().mockReturnValue(`ws://localhost:${port}/comms`) });
     const checker = new NodeErrorChecker(client);
 
     wss.on('connection', ws => {
@@ -152,7 +152,7 @@ describe('NodeErrorChecker', () => {
   it('enriches nodes with flow metadata', async () => {
     const { wss, port, close } = await startWss();
     const client = makeClient({
-      getBaseURL: vi.fn().mockReturnValue(`http://localhost:${port}`),
+      getCommsWsUrl: vi.fn().mockReturnValue(`ws://localhost:${port}/comms`),
       getFlows: vi.fn().mockResolvedValue([
         {
           id: 'flow-1',
@@ -183,7 +183,7 @@ describe('NodeErrorChecker', () => {
   it('returns unknown metadata for nodes not in any flow', async () => {
     const { wss, port, close } = await startWss();
     const client = makeClient({
-      getBaseURL: vi.fn().mockReturnValue(`http://localhost:${port}`),
+      getCommsWsUrl: vi.fn().mockReturnValue(`ws://localhost:${port}/comms`),
       getFlows: vi.fn().mockResolvedValue([]),
     });
     const checker = new NodeErrorChecker(client);
@@ -207,7 +207,7 @@ describe('NodeErrorChecker', () => {
 
   it('rejects with auth error when WS returns auth:fail', async () => {
     const { wss, port, close } = await startWss();
-    const client = makeClient({ getBaseURL: vi.fn().mockReturnValue(`http://localhost:${port}`) });
+    const client = makeClient({ getCommsWsUrl: vi.fn().mockReturnValue(`ws://localhost:${port}/comms`) });
     const checker = new NodeErrorChecker(client);
 
     wss.on('connection', ws => {
@@ -221,7 +221,7 @@ describe('NodeErrorChecker', () => {
 
   it('caps timeoutMs at 30000', async () => {
     const { wss, port, close } = await startWss();
-    const client = makeClient({ getBaseURL: vi.fn().mockReturnValue(`http://localhost:${port}`) });
+    const client = makeClient({ getCommsWsUrl: vi.fn().mockReturnValue(`ws://localhost:${port}/comms`) });
     const checker = new NodeErrorChecker(client);
 
     // Should not hang — pass 99999 but it gets capped and we just check it starts

--- a/src/services/node-error-checker.test.ts
+++ b/src/services/node-error-checker.test.ts
@@ -1,0 +1,236 @@
+import { createServer } from 'http';
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WebSocketServer } from 'ws';
+
+import { getNodeRedAuthHeader } from '../utils/auth.js';
+
+import { NodeErrorChecker } from './node-error-checker.js';
+import { NodeRedAPIClient } from './nodered-api.js';
+
+vi.mock('../utils/auth.js', () => ({
+  getNodeRedAuthHeader: vi.fn().mockReturnValue({}),
+  getTlsRejectUnauthorized: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('./nodered-api.js', () => ({
+  NodeRedAPIClient: vi.fn().mockImplementation(() => ({
+    getBaseURL: vi.fn().mockReturnValue('http://localhost:0'),
+    getFlows: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+interface FakeClient {
+  getBaseURL: ReturnType<typeof vi.fn>;
+  getFlows: ReturnType<typeof vi.fn>;
+}
+
+function makeClient(overrides: Partial<FakeClient> = {}): NodeRedAPIClient {
+  const defaults: FakeClient = {
+    getBaseURL: vi.fn().mockReturnValue('http://localhost:0'),
+    getFlows: vi.fn().mockResolvedValue([]),
+  };
+  return { ...defaults, ...overrides } as unknown as NodeRedAPIClient;
+}
+
+function startWss(): Promise<{
+  wss: WebSocketServer;
+  port: number;
+  close: () => Promise<void>;
+}> {
+  return new Promise(resolve => {
+    const server = createServer();
+    const wss = new WebSocketServer({ server });
+    server.listen(0, () => {
+      const { port } = server.address() as { port: number };
+      const close = () =>
+        new Promise<void>(res => wss.close(() => server.close(() => res())));
+      resolve({ wss, port, close });
+    });
+  });
+}
+
+describe('NodeErrorChecker', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(getNodeRedAuthHeader).mockReturnValue({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns empty errors when no status messages arrive within timeout', async () => {
+    const { wss, port, close } = await startWss();
+    const client = makeClient({ getBaseURL: vi.fn().mockReturnValue(`http://localhost:${port}`) });
+    const checker = new NodeErrorChecker(client);
+
+    const result = await checker.check({ timeoutMs: 100 });
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+    expect(result.statusesMayBeIncomplete).toBe(true);
+
+    wss.close();
+    await close();
+  });
+
+  it('returns a red node in errors', async () => {
+    const { wss, port, close } = await startWss();
+    const client = makeClient({ getBaseURL: vi.fn().mockReturnValue(`http://localhost:${port}`) });
+    const checker = new NodeErrorChecker(client);
+
+    wss.on('connection', ws => {
+      ws.send(JSON.stringify({ topic: 'status/node-1', data: { fill: 'red', text: 'not connected' } }));
+    });
+
+    const result = await checker.check({ timeoutMs: 300 });
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]!.nodeId).toBe('node-1');
+    expect(result.errors[0]!.status.fill).toBe('red');
+    expect(result.errors[0]!.status.text).toBe('not connected');
+    expect(result.statusesMayBeIncomplete).toBe(false);
+
+    await close();
+  });
+
+  it('deduplicates: red then green → not in errors', async () => {
+    const { wss, port, close } = await startWss();
+    const client = makeClient({ getBaseURL: vi.fn().mockReturnValue(`http://localhost:${port}`) });
+    const checker = new NodeErrorChecker(client);
+
+    wss.on('connection', ws => {
+      ws.send(JSON.stringify({ topic: 'status/node-1', data: { fill: 'red', text: 'error' } }));
+      setTimeout(() => {
+        ws.send(JSON.stringify({ topic: 'status/node-1', data: { fill: 'green', text: 'connected' } }));
+      }, 20);
+    });
+
+    const result = await checker.check({ timeoutMs: 200 });
+
+    expect(result.errors).toHaveLength(0);
+
+    await close();
+  });
+
+  it('does not include yellow nodes when includeWarnings is false', async () => {
+    const { wss, port, close } = await startWss();
+    const client = makeClient({ getBaseURL: vi.fn().mockReturnValue(`http://localhost:${port}`) });
+    const checker = new NodeErrorChecker(client);
+
+    wss.on('connection', ws => {
+      ws.send(JSON.stringify({ topic: 'status/node-1', data: { fill: 'yellow', text: 'warn' } }));
+    });
+
+    const result = await checker.check({ timeoutMs: 200, includeWarnings: false });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+
+    await close();
+  });
+
+  it('includes yellow nodes when includeWarnings is true', async () => {
+    const { wss, port, close } = await startWss();
+    const client = makeClient({ getBaseURL: vi.fn().mockReturnValue(`http://localhost:${port}`) });
+    const checker = new NodeErrorChecker(client);
+
+    wss.on('connection', ws => {
+      ws.send(JSON.stringify({ topic: 'status/node-1', data: { fill: 'yellow', text: 'warn' } }));
+    });
+
+    const result = await checker.check({ timeoutMs: 200, includeWarnings: true });
+
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]!.status.fill).toBe('yellow');
+
+    await close();
+  });
+
+  it('enriches nodes with flow metadata', async () => {
+    const { wss, port, close } = await startWss();
+    const client = makeClient({
+      getBaseURL: vi.fn().mockReturnValue(`http://localhost:${port}`),
+      getFlows: vi.fn().mockResolvedValue([
+        {
+          id: 'flow-1',
+          label: 'My Flow',
+          nodes: [{ id: 'node-1', type: 'mqtt in', name: 'Listen MQTT' }],
+        },
+      ]),
+    });
+    const checker = new NodeErrorChecker(client);
+
+    wss.on('connection', ws => {
+      ws.send(JSON.stringify({ topic: 'status/node-1', data: { fill: 'red', text: 'no broker' } }));
+    });
+
+    const result = await checker.check({ timeoutMs: 200 });
+
+    expect(result.errors[0]).toMatchObject({
+      nodeId: 'node-1',
+      nodeType: 'mqtt in',
+      label: 'Listen MQTT',
+      flowId: 'flow-1',
+      flowName: 'My Flow',
+    });
+
+    await close();
+  });
+
+  it('returns unknown metadata for nodes not in any flow', async () => {
+    const { wss, port, close } = await startWss();
+    const client = makeClient({
+      getBaseURL: vi.fn().mockReturnValue(`http://localhost:${port}`),
+      getFlows: vi.fn().mockResolvedValue([]),
+    });
+    const checker = new NodeErrorChecker(client);
+
+    wss.on('connection', ws => {
+      ws.send(JSON.stringify({ topic: 'status/node-orphan', data: { fill: 'red', text: 'error' } }));
+    });
+
+    const result = await checker.check({ timeoutMs: 200 });
+
+    expect(result.errors[0]).toMatchObject({
+      nodeId: 'node-orphan',
+      nodeType: 'unknown',
+      label: '',
+      flowId: '',
+      flowName: '',
+    });
+
+    await close();
+  });
+
+  it('rejects with auth error when WS returns auth:fail', async () => {
+    const { wss, port, close } = await startWss();
+    const client = makeClient({ getBaseURL: vi.fn().mockReturnValue(`http://localhost:${port}`) });
+    const checker = new NodeErrorChecker(client);
+
+    wss.on('connection', ws => {
+      ws.send(JSON.stringify({ topic: 'auth', data: 'fail' }));
+    });
+
+    await expect(checker.check({ timeoutMs: 500 })).rejects.toThrow('auth failed');
+
+    await close();
+  });
+
+  it('caps timeoutMs at 30000', async () => {
+    const { wss, port, close } = await startWss();
+    const client = makeClient({ getBaseURL: vi.fn().mockReturnValue(`http://localhost:${port}`) });
+    const checker = new NodeErrorChecker(client);
+
+    // Should not hang — pass 99999 but it gets capped and we just check it starts
+    // (we close the WS immediately to end the check)
+    wss.on('connection', ws => ws.close());
+
+    const result = await checker.check({ timeoutMs: 99999 });
+    expect(result).toBeDefined();
+
+    await close();
+  });
+});

--- a/src/services/node-error-checker.ts
+++ b/src/services/node-error-checker.ts
@@ -1,6 +1,7 @@
 import WebSocket from 'ws';
 
 import { getNodeRedAuthHeader, getTlsRejectUnauthorized } from '../utils/auth.js';
+import { AuthenticationError } from '../utils/error-handling.js';
 
 import { NodeRedAPIClient } from './nodered-api.js';
 
@@ -21,25 +22,23 @@ export interface NodeErrorCheckResult {
 
 interface RawStatus { fill?: string; shape?: string; text?: string }
 
-function toWsUrl(baseURL: string): string {
-  return `${baseURL
-    .replace(/^https:\/\//, 'wss://')
-    .replace(/^http:\/\//, 'ws://')
-    .replace(/\/$/, '')}/comms`;
-}
-
-function collectStatuses(wsUrl: string, timeoutMs: number): Promise<Map<string, RawStatus>> {
+function collectStatuses(
+  wsUrl: string,
+  timeoutMs: number,
+): Promise<{ statuses: Map<string, RawStatus>; connected: boolean }> {
   return new Promise((resolve, reject) => {
     const statuses = new Map<string, RawStatus>();
     let ws: WebSocket | null = null;
     let settled = false;
+    let connected = false;
 
-    const finish = () => {
+    const finish = (err?: Error) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
       ws?.terminate();
-      resolve(statuses);
+      if (err) reject(err);
+      else resolve({ statuses, connected });
     };
 
     const timer = setTimeout(finish, timeoutMs);
@@ -55,6 +54,8 @@ function collectStatuses(wsUrl: string, timeoutMs: number): Promise<Map<string, 
       return;
     }
 
+    ws.on('open', () => { connected = true; });
+
     ws.on('message', (raw: WebSocket.RawData) => {
       try {
         // eslint-disable-next-line @typescript-eslint/no-base-to-string
@@ -62,10 +63,7 @@ function collectStatuses(wsUrl: string, timeoutMs: number): Promise<Map<string, 
 
         if (msg.topic === 'auth') {
           if (msg.data === 'fail') {
-            settled = true;
-            clearTimeout(timer);
-            ws?.terminate();
-            reject(new Error('Node-RED WebSocket auth failed'));
+            finish(new AuthenticationError('Node-RED WebSocket auth failed'));
           }
           return;
         }
@@ -91,8 +89,8 @@ function collectStatuses(wsUrl: string, timeoutMs: number): Promise<Map<string, 
       }
     });
 
-    ws.on('close', finish);
-    ws.on('error', finish);
+    ws.on('close', () => finish());
+    ws.on('error', () => finish());
   });
 }
 
@@ -106,15 +104,10 @@ export class NodeErrorChecker {
     const includeWarnings = opts.includeWarnings ?? false;
     const timeoutMs = Math.min(opts.timeoutMs ?? 2000, 30000);
 
-    const wsUrl = toWsUrl(this.apiClient.getBaseURL());
-    const statuses = await collectStatuses(wsUrl, timeoutMs);
-
-    let flows: Awaited<ReturnType<NodeRedAPIClient['getFlows']>> = [];
-    try {
-      flows = await this.apiClient.getFlows();
-    } catch {
-      // proceed without enrichment
-    }
+    const [{ statuses, connected }, flows] = await Promise.all([
+      collectStatuses(this.apiClient.getCommsWsUrl(), timeoutMs),
+      this.apiClient.getFlows().catch((): Awaited<ReturnType<NodeRedAPIClient['getFlows']>> => []),
+    ]);
 
     const nodeIndex = new Map<string, { nodeType: string; label: string; flowId: string; flowName: string }>();
     for (const flow of flows) {
@@ -157,7 +150,7 @@ export class NodeErrorChecker {
     return {
       errors,
       warnings,
-      statusesMayBeIncomplete: statuses.size === 0,
+      statusesMayBeIncomplete: !connected,
     };
   }
 }

--- a/src/services/node-error-checker.ts
+++ b/src/services/node-error-checker.ts
@@ -1,0 +1,163 @@
+import WebSocket from 'ws';
+
+import { getNodeRedAuthHeader, getTlsRejectUnauthorized } from '../utils/auth.js';
+
+import { NodeRedAPIClient } from './nodered-api.js';
+
+export interface NodeErrorEntry {
+  nodeId: string;
+  nodeType: string;
+  label: string;
+  status: { fill: string; shape?: string; text?: string };
+  flowId: string;
+  flowName: string;
+}
+
+export interface NodeErrorCheckResult {
+  errors: NodeErrorEntry[];
+  warnings: NodeErrorEntry[];
+  statusesMayBeIncomplete: boolean;
+}
+
+interface RawStatus { fill?: string; shape?: string; text?: string }
+
+function toWsUrl(baseURL: string): string {
+  return `${baseURL
+    .replace(/^https:\/\//, 'wss://')
+    .replace(/^http:\/\//, 'ws://')
+    .replace(/\/$/, '')}/comms`;
+}
+
+function collectStatuses(wsUrl: string, timeoutMs: number): Promise<Map<string, RawStatus>> {
+  return new Promise((resolve, reject) => {
+    const statuses = new Map<string, RawStatus>();
+    let ws: WebSocket | null = null;
+    let settled = false;
+
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      ws?.terminate();
+      resolve(statuses);
+    };
+
+    const timer = setTimeout(finish, timeoutMs);
+
+    try {
+      ws = new WebSocket(wsUrl, {
+        rejectUnauthorized: getTlsRejectUnauthorized(),
+        headers: getNodeRedAuthHeader(),
+      });
+    } catch (err) {
+      clearTimeout(timer);
+      reject(err);
+      return;
+    }
+
+    ws.on('message', (raw: WebSocket.RawData) => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
+        const msg = JSON.parse(raw.toString()) as { topic: string; data?: any };
+
+        if (msg.topic === 'auth') {
+          if (msg.data === 'fail') {
+            settled = true;
+            clearTimeout(timer);
+            ws?.terminate();
+            reject(new Error('Node-RED WebSocket auth failed'));
+          }
+          return;
+        }
+
+        if (msg.topic.startsWith('status/')) {
+          const nodeId = msg.topic.slice('status/'.length);
+          const d = (msg.data ?? {}) as Record<string, unknown>;
+          const fill = typeof d.fill === 'string' ? d.fill : undefined;
+          const shape = typeof d.shape === 'string' ? d.shape : undefined;
+          const text = typeof d.text === 'string' ? d.text : undefined;
+          if (!fill && !text) {
+            statuses.delete(nodeId);
+          } else {
+            const s: RawStatus = {};
+            if (fill !== undefined) s.fill = fill;
+            if (shape !== undefined) s.shape = shape;
+            if (text !== undefined) s.text = text;
+            statuses.set(nodeId, s);
+          }
+        }
+      } catch {
+        // ignore malformed frames
+      }
+    });
+
+    ws.on('close', finish);
+    ws.on('error', finish);
+  });
+}
+
+export class NodeErrorChecker {
+  constructor(private readonly apiClient: NodeRedAPIClient) {}
+
+  async check(opts: {
+    includeWarnings?: boolean;
+    timeoutMs?: number;
+  } = {}): Promise<NodeErrorCheckResult> {
+    const includeWarnings = opts.includeWarnings ?? false;
+    const timeoutMs = Math.min(opts.timeoutMs ?? 2000, 30000);
+
+    const wsUrl = toWsUrl(this.apiClient.getBaseURL());
+    const statuses = await collectStatuses(wsUrl, timeoutMs);
+
+    let flows: Awaited<ReturnType<NodeRedAPIClient['getFlows']>> = [];
+    try {
+      flows = await this.apiClient.getFlows();
+    } catch {
+      // proceed without enrichment
+    }
+
+    const nodeIndex = new Map<string, { nodeType: string; label: string; flowId: string; flowName: string }>();
+    for (const flow of flows) {
+      const flowName = flow.label ?? flow.id;
+      for (const node of flow.nodes ?? []) {
+        nodeIndex.set(node.id, {
+          nodeType: node.type ?? 'unknown',
+          label: node.name ?? '',
+          flowId: flow.id,
+          flowName,
+        });
+      }
+    }
+
+    const errors: NodeErrorEntry[] = [];
+    const warnings: NodeErrorEntry[] = [];
+
+    for (const [nodeId, rawStatus] of statuses) {
+      const { fill, shape, text } = rawStatus;
+      if (!fill) continue;
+      const meta = nodeIndex.get(nodeId);
+      const status: NodeErrorEntry['status'] = { fill };
+      if (shape !== undefined) status.shape = shape;
+      if (text !== undefined) status.text = text;
+      const entry: NodeErrorEntry = {
+        nodeId,
+        nodeType: meta?.nodeType ?? 'unknown',
+        label: meta?.label ?? '',
+        status,
+        flowId: meta?.flowId ?? '',
+        flowName: meta?.flowName ?? '',
+      };
+      if (fill === 'red') {
+        errors.push(entry);
+      } else if (fill === 'yellow' && includeWarnings) {
+        warnings.push(entry);
+      }
+    }
+
+    return {
+      errors,
+      warnings,
+      statusesMayBeIncomplete: statuses.size === 0,
+    };
+  }
+}

--- a/src/services/nodered-api.ts
+++ b/src/services/nodered-api.ts
@@ -249,8 +249,11 @@ export class NodeRedAPIClient {
     return updatedFlow;
   }
 
-  getBaseURL(): string {
-    return this.config.baseURL;
+  getCommsWsUrl(): string {
+    return `${this.config.baseURL
+      .replace(/^https:\/\//, 'wss://')
+      .replace(/^http:\/\//, 'ws://')
+      .replace(/\/$/, '')}/comms`;
   }
 
   /**

--- a/src/services/nodered-api.ts
+++ b/src/services/nodered-api.ts
@@ -249,6 +249,10 @@ export class NodeRedAPIClient {
     return updatedFlow;
   }
 
+  getBaseURL(): string {
+    return this.config.baseURL;
+  }
+
   /**
    * Test connection to Node-RED
    */


### PR DESCRIPTION
## Summary

- Adds `get_node_errors` MCP tool that connects to Node-RED's WebSocket `/comms` endpoint, collects retained node status events, and returns nodes with active red (error) or yellow (warning) statuses
- Adds `NodeErrorChecker` service (`src/services/node-error-checker.ts`) — one-shot WS connection, deduplicates statuses (last status per node wins), enriches results with nodeType/label/flowId/flowName via `getFlows()`
- Adds `getBaseURL()` to `NodeRedAPIClient` so `NodeErrorChecker` can resolve the WS URL without accessing private config
- 9 unit tests for `NodeErrorChecker` using a real in-process WebSocket server
- 3 integration tests in `mcp-server.test.ts` for the new tool case

## Test plan

- [ ] All 877 existing tests pass (`pnpm test`)
- [ ] No TypeScript errors (`pnpm build`)
- [ ] No ESLint errors (`pnpm lint`)
- [ ] After deploying: call `get_node_errors` via MCP and verify it returns correct error/warning nodes from live Node-RED instance