### PR TITLE
Fix: NODERED_USERNAME/PASSWORD auth sends unsupported Basic header (401 on every request)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,21 @@ and this project adheres to
 
 ### Fixed
 
+- **Node-RED Username/Password Authentication**: `NODERED_USERNAME` +
+  `NODERED_PASSWORD` previously sent a static HTTP Basic auth header on every
+  request, which Node-RED's admin API does not accept (it only accepts Bearer
+  tokens issued via the `/auth/token` password grant) — every request in this
+  mode failed with `401`
+  - The credentials are now exchanged for a bearer token on demand, cached in
+    memory, and transparently re-exchanged shortly before expiry or immediately
+    after a `401`
+  - A client constructed with an explicit `Authorization` header (used by the
+    per-tenant OAuth path in `callToolPublic`) is left untouched — the new token
+    resolution never overwrites tenant-supplied credentials
+  - The token exchange now respects `NODERED_TIMEOUT` like the rest of the
+    client, instead of being able to hang indefinitely
+  - Added unit tests covering token caching/reuse, forced refresh, concurrent
+    request de-duplication, the 401-retry-once path, and the per-tenant override
 - **TypeScript Strict Mode Compliance**: Resolved all
   `exactOptionalPropertyTypes` errors
   - Fixed SSEConnection, SSEClientInfo, SSEError type definitions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,21 +61,40 @@ and this project adheres to
 
 ### Fixed
 
-- **Node-RED Username/Password Authentication**: `NODERED_USERNAME` +
-  `NODERED_PASSWORD` previously sent a static HTTP Basic auth header on every
-  request, which Node-RED's admin API does not accept (it only accepts Bearer
-  tokens issued via the `/auth/token` password grant) — every request in this
-  mode failed with `401`
-  - The credentials are now exchanged for a bearer token on demand, cached in
-    memory, and transparently re-exchanged shortly before expiry or immediately
-    after a `401`
+- **Node-RED Username/Password Authentication**: when `NODERED_USERNAME` +
+  `NODERED_PASSWORD` are Node-RED's own `adminAuth` credentials, sending them as
+  a static HTTP Basic header on every request doesn't work — Node-RED's admin
+  API only accepts Bearer tokens issued via the `/auth/token` password grant, so
+  every request in this mode failed with `401`
+  - New opt-in `NODERED_ADMIN_AUTH_ENABLED=true` switches to exchanging the
+    credentials for a Bearer token on demand, cached in memory and transparently
+    re-exchanged shortly before expiry or immediately after a `401`. Left unset
+    (the default), the existing static Basic header is sent unchanged — for
+    deployments where these credentials actually belong to a reverse proxy in
+    front of Node-RED rather than Node-RED's own `adminAuth`, which is a real,
+    supported setup and not something this fix should break
+  - Node-RED's `/comms` WebSocket (used by `get_node_errors`) authenticates
+    entirely in-band — an `{ auth: "<token>" }` message sent right after the
+    connection opens, not via connection headers — so it was never actually
+    authenticating regardless of Basic vs. Bearer. Both WebSocket entry points
+    now send the real handshake when `NODERED_ADMIN_AUTH_ENABLED` or
+    `NODERED_API_TOKEN` provide a token, and correctly parse Node-RED's actual
+    wire format (a flat `{ auth: "ok" | "fail" }` reply; regular events arrive
+    batched as a JSON array per message, not one object per message)
+  - `get_node_errors`'s `statusesMayBeIncomplete` previously reflected only
+    whether the socket was open, so an unauthenticated connection (silently
+    muted by Node-RED rather than closed) reported a confident, wrong "no
+    errors" — it now also accounts for whether the handshake was actually
+    confirmed
   - A client constructed with an explicit `Authorization` header (used by the
     per-tenant OAuth path in `callToolPublic`) is left untouched — the new token
     resolution never overwrites tenant-supplied credentials
-  - The token exchange now respects `NODERED_TIMEOUT` like the rest of the
-    client, instead of being able to hang indefinitely
+  - The token exchange respects `NODERED_TIMEOUT` like the rest of the client,
+    instead of being able to hang indefinitely
   - Added unit tests covering token caching/reuse, forced refresh, concurrent
-    request de-duplication, the 401-retry-once path, and the per-tenant override
+    request de-duplication, the 401-retry-once path, the per-tenant override,
+    the opt-in gate, and the WebSocket handshake (including the batched-array
+    wire format and the corrected `statusesMayBeIncomplete` logic)
 - **TypeScript Strict Mode Compliance**: Resolved all
   `exactOptionalPropertyTypes` errors
   - Fixed SSEConnection, SSEClientInfo, SSEError type definitions

--- a/README.md
+++ b/README.md
@@ -235,13 +235,13 @@ If none of these are set, requests are sent unauthenticated — only appropriate
 when Node-RED's `adminAuth` is disabled and nothing sits in front of the
 instance either.
 
-**Known limitation:** these two topologies are mutually exclusive today. If
-you genuinely run *both* — a reverse-proxy Basic-auth layer in front of an
-instance that also has Node-RED's own `adminAuth` enabled — there's currently
-no way to supply separate credentials for each; `NODERED_USERNAME`/`PASSWORD`
-can only be exchanged for a token *or* sent as a static Basic header, not
-both at once for two different recipients. Supporting that would need a
-second, distinct credential pair sent independently of the Bearer exchange.
+**Known limitation:** these two topologies are mutually exclusive today. If you
+genuinely run _both_ — a reverse-proxy Basic-auth layer in front of an instance
+that also has Node-RED's own `adminAuth` enabled — there's currently no way to
+supply separate credentials for each; `NODERED_USERNAME`/`PASSWORD` can only be
+exchanged for a token _or_ sent as a static Basic header, not both at once for
+two different recipients. Supporting that would need a second, distinct
+credential pair sent independently of the Bearer exchange.
 
 ## ⚙️ Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ nodes in error/warning state in real time.
 - [Resources](#-mcp-resources)
 - [Prompts](#-mcp-prompts)
 - [Connecting](#-connecting-to-the-server)
+- [Node-RED Authentication](#node-red-authentication)
 - [Environment Variables](#-environment-variables)
 
 ## ⚡ Quick Start
@@ -201,13 +202,31 @@ claude mcp add node-red \
   --header "Authorization: Basic <base64-credentials>"
 ```
 
+### Node-RED Authentication
+
+Node-RED's admin API only accepts a **Bearer token** — it does not support
+HTTP Basic auth. There are two ways to authenticate against it:
+
+- **`NODERED_USERNAME` + `NODERED_PASSWORD`** (recommended) — the server
+  exchanges these for a token via Node-RED's `/auth/token` password grant on
+  first use, caches it in memory, and transparently re-exchanges it shortly
+  before it expires (or immediately after a `401`). You never see the token.
+- **`NODERED_API_TOKEN`** — supply an already-issued bearer token directly
+  (e.g. one you obtained yourself via `/auth/token`). Useful if you don't want
+  this server to hold your Node-RED password, at the cost of having to
+  refresh the token yourself once it expires.
+
+If neither is set, requests are sent unauthenticated — only appropriate when
+Node-RED's `adminAuth` is disabled.
+
 ## ⚙️ Environment Variables
 
 | Variable                      | Required | Default                   | Description                                                                                    |
 | ----------------------------- | -------- | ------------------------- | ---------------------------------------------------------------------------------------------- |
 | `NODERED_URL`                 | Yes      | —                         | URL of your Node-RED instance                                                                  |
-| `NODERED_USERNAME`            | No       | —                         | Node-RED admin username                                                                        |
-| `NODERED_PASSWORD`            | No       | —                         | Node-RED admin password                                                                        |
+| `NODERED_USERNAME`            | No       | —                         | Node-RED admin username (exchanged for a bearer token automatically)                            |
+| `NODERED_PASSWORD`            | No       | —                         | Node-RED admin password (exchanged for a bearer token automatically)                            |
+| `NODERED_API_TOKEN`           | No       | —                         | Pre-issued Node-RED bearer token; takes precedence over username/password                       |
 | `MCP_TRANSPORT`               | No       | `http`                    | `http` or `stdio`                                                                              |
 | `MCP_USERNAME`                | No       | —                         | MCP server auth username                                                                       |
 | `MCP_PASSWORD`                | No       | —                         | MCP server auth password                                                                       |

--- a/README.md
+++ b/README.md
@@ -235,6 +235,14 @@ If none of these are set, requests are sent unauthenticated — only appropriate
 when Node-RED's `adminAuth` is disabled and nothing sits in front of the
 instance either.
 
+**Known limitation:** these two topologies are mutually exclusive today. If
+you genuinely run *both* — a reverse-proxy Basic-auth layer in front of an
+instance that also has Node-RED's own `adminAuth` enabled — there's currently
+no way to supply separate credentials for each; `NODERED_USERNAME`/`PASSWORD`
+can only be exchanged for a token *or* sent as a static Basic header, not
+both at once for two different recipients. Supporting that would need a
+second, distinct credential pair sent independently of the Bearer exchange.
+
 ## ⚙️ Environment Variables
 
 | Variable                      | Required | Default                   | Description                                                                                                                                                     |

--- a/README.md
+++ b/README.md
@@ -204,35 +204,52 @@ claude mcp add node-red \
 
 ### Node-RED Authentication
 
-Node-RED's admin API only accepts a **Bearer token** — it does not support
-HTTP Basic auth. There are two ways to authenticate against it:
+`NODERED_USERNAME`/`NODERED_PASSWORD` mean one of two different things depending
+on your deployment, and this server needs to know which:
 
-- **`NODERED_USERNAME` + `NODERED_PASSWORD`** (recommended) — the server
-  exchanges these for a token via Node-RED's `/auth/token` password grant on
-  first use, caches it in memory, and transparently re-exchanges it shortly
-  before it expires (or immediately after a `401`). You never see the token.
-- **`NODERED_API_TOKEN`** — supply an already-issued bearer token directly
-  (e.g. one you obtained yourself via `/auth/token`). Useful if you don't want
-  this server to hold your Node-RED password, at the cost of having to
-  refresh the token yourself once it expires.
+- **Node-RED's own `adminAuth` is enabled** — these are Node-RED's own admin
+  credentials. Set **`NODERED_ADMIN_AUTH_ENABLED=true`** and the server
+  exchanges them for a Bearer token via Node-RED's `/auth/token` password grant
+  on first use (Node-RED's admin API only accepts Bearer tokens, not HTTP Basic
+  auth — this is required, not optional, in this mode). The token is cached in
+  memory and transparently re-exchanged shortly before it expires (or
+  immediately after a `401`). You never see the token. The same in-band exchange
+  also authenticates the `/comms` WebSocket used by `get_node_errors`, since
+  Node-RED's WebSocket auth is its own separate in-band handshake, not
+  header-based.
+- **The credentials belong to something in front of Node-RED** — e.g. an nginx
+  or Traefik Basic-auth layer gating every request to the whole instance,
+  unrelated to Node-RED's own auth. Leave `NODERED_ADMIN_AUTH_ENABLED` unset
+  (the default). The server sends a static HTTP Basic header built from
+  `NODERED_USERNAME`/`NODERED_PASSWORD` on every request, including the
+  WebSocket upgrade — exactly what a proxy in this position expects, and exactly
+  what Node-RED's own admin API would reject if its `adminAuth` were enabled.
 
-If neither is set, requests are sent unauthenticated — only appropriate when
-Node-RED's `adminAuth` is disabled.
+Alternatively, **`NODERED_API_TOKEN`** supplies an already-issued Node-RED
+bearer token directly (e.g. one you obtained yourself via `/auth/token`). Useful
+if you don't want this server to hold your Node-RED password, at the cost of
+having to refresh the token yourself once it expires. This mode is unaffected by
+`NODERED_ADMIN_AUTH_ENABLED`.
+
+If none of these are set, requests are sent unauthenticated — only appropriate
+when Node-RED's `adminAuth` is disabled and nothing sits in front of the
+instance either.
 
 ## ⚙️ Environment Variables
 
-| Variable                      | Required | Default                   | Description                                                                                    |
-| ----------------------------- | -------- | ------------------------- | ---------------------------------------------------------------------------------------------- |
-| `NODERED_URL`                 | Yes      | —                         | URL of your Node-RED instance                                                                  |
-| `NODERED_USERNAME`            | No       | —                         | Node-RED admin username (exchanged for a bearer token automatically)                            |
-| `NODERED_PASSWORD`            | No       | —                         | Node-RED admin password (exchanged for a bearer token automatically)                            |
-| `NODERED_API_TOKEN`           | No       | —                         | Pre-issued Node-RED bearer token; takes precedence over username/password                       |
-| `MCP_TRANSPORT`               | No       | `http`                    | `http` or `stdio`                                                                              |
-| `MCP_USERNAME`                | No       | —                         | MCP server auth username                                                                       |
-| `MCP_PASSWORD`                | No       | —                         | MCP server auth password                                                                       |
-| `MCP_READ_ONLY`               | No       | `false`                   | Set `true` to hide write tools and reject write calls — see [Read-Only Mode](#-read-only-mode) |
-| `HOST`                        | No       | `0.0.0.0`                 | Bind address                                                                                   |
-| `PORT`                        | No       | `3000`                    | Listen port                                                                                    |
-| `LOG_LEVEL`                   | No       | `info`                    | `debug`, `info`, `warn`, `error`                                                               |
-| `NODERED_REJECT_UNAUTHORIZED` | No       | `true`                    | Set `false` to allow self-signed TLS                                                           |
-| `EMBEDDING_MODEL`             | No       | `Xenova/all-MiniLM-L6-v2` | Model for semantic search                                                                      |
+| Variable                      | Required | Default                   | Description                                                                                                                                                     |
+| ----------------------------- | -------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NODERED_URL`                 | Yes      | —                         | URL of your Node-RED instance                                                                                                                                   |
+| `NODERED_USERNAME`            | No       | —                         | Node-RED admin username, or a reverse-proxy Basic-auth username — see [Node-RED Authentication](#node-red-authentication)                                       |
+| `NODERED_PASSWORD`            | No       | —                         | Node-RED admin password, or a reverse-proxy Basic-auth password — see [Node-RED Authentication](#node-red-authentication)                                       |
+| `NODERED_ADMIN_AUTH_ENABLED`  | No       | `false`                   | Set `true` when `NODERED_USERNAME`/`PASSWORD` are Node-RED's _own_ `adminAuth` credentials, to exchange them for a Bearer token instead of sending static Basic |
+| `NODERED_API_TOKEN`           | No       | —                         | Pre-issued Node-RED bearer token; takes precedence over username/password                                                                                       |
+| `MCP_TRANSPORT`               | No       | `http`                    | `http` or `stdio`                                                                                                                                               |
+| `MCP_USERNAME`                | No       | —                         | MCP server auth username                                                                                                                                        |
+| `MCP_PASSWORD`                | No       | —                         | MCP server auth password                                                                                                                                        |
+| `MCP_READ_ONLY`               | No       | `false`                   | Set `true` to hide write tools and reject write calls — see [Read-Only Mode](#-read-only-mode)                                                                  |
+| `HOST`                        | No       | `0.0.0.0`                 | Bind address                                                                                                                                                    |
+| `PORT`                        | No       | `3000`                    | Listen port                                                                                                                                                     |
+| `LOG_LEVEL`                   | No       | `info`                    | `debug`, `info`, `warn`, `error`                                                                                                                                |
+| `NODERED_REJECT_UNAUTHORIZED` | No       | `true`                    | Set `false` to allow self-signed TLS                                                                                                                            |
+| `EMBEDDING_MODEL`             | No       | `Xenova/all-MiniLM-L6-v2` | Model for semantic search                                                                                                                                       |

--- a/src/services/node-error-checker.test.ts
+++ b/src/services/node-error-checker.test.ts
@@ -3,13 +3,14 @@ import { createServer } from 'http';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { WebSocketServer } from 'ws';
 
-import { resolveNodeRedAuthHeader } from '../utils/auth.js';
+import { resolveNodeRedAuthHeader, resolveNodeRedAuthToken } from '../utils/auth.js';
 
 import { NodeErrorChecker } from './node-error-checker.js';
 import { NodeRedAPIClient } from './nodered-api.js';
 
 vi.mock('../utils/auth.js', () => ({
   resolveNodeRedAuthHeader: vi.fn().mockResolvedValue({}),
+  resolveNodeRedAuthToken: vi.fn().mockResolvedValue(undefined),
   getTlsRejectUnauthorized: vi.fn().mockReturnValue(true),
 }));
 
@@ -54,6 +55,7 @@ describe('NodeErrorChecker', () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.mocked(resolveNodeRedAuthHeader).mockResolvedValue({});
+    vi.mocked(resolveNodeRedAuthToken).mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -228,10 +230,53 @@ describe('NodeErrorChecker', () => {
     const checker = new NodeErrorChecker(client);
 
     wss.on('connection', ws => {
-      ws.send(JSON.stringify({ topic: 'auth', data: 'fail' }));
+      ws.send(JSON.stringify({ auth: 'fail' }));
     });
 
     await expect(checker.check({ timeoutMs: 500 })).rejects.toThrow('auth failed');
+
+    await close();
+  });
+
+  it('flags statusesMayBeIncomplete when a token was sent but never confirmed', async () => {
+    vi.mocked(resolveNodeRedAuthToken).mockResolvedValue('some-token');
+
+    const { wss, port, close } = await startWss();
+    const client = makeClient({
+      getCommsWsUrl: vi.fn().mockReturnValue(`ws://localhost:${port}/comms`),
+    });
+    const checker = new NodeErrorChecker(client);
+
+    // Server accepts the connection but never sends { auth: 'ok' } or any
+    // status frame — this is the previously-silent false-negative case.
+    wss.on('connection', () => {});
+
+    const result = await checker.check({ timeoutMs: 100 });
+
+    expect(result.errors).toEqual([]);
+    expect(result.statusesMayBeIncomplete).toBe(true);
+
+    await close();
+  });
+
+  it('does not flag statusesMayBeIncomplete once auth is confirmed and data arrives', async () => {
+    vi.mocked(resolveNodeRedAuthToken).mockResolvedValue('some-token');
+
+    const { wss, port, close } = await startWss();
+    const client = makeClient({
+      getCommsWsUrl: vi.fn().mockReturnValue(`ws://localhost:${port}/comms`),
+    });
+    const checker = new NodeErrorChecker(client);
+
+    wss.on('connection', ws => {
+      ws.send(JSON.stringify({ auth: 'ok' }));
+      ws.send(JSON.stringify({ topic: 'status/node-1', data: { fill: 'red', text: 'err' } }));
+    });
+
+    const result = await checker.check({ timeoutMs: 200 });
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.statusesMayBeIncomplete).toBe(false);
 
     await close();
   });

--- a/src/services/node-error-checker.test.ts
+++ b/src/services/node-error-checker.test.ts
@@ -3,13 +3,13 @@ import { createServer } from 'http';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { WebSocketServer } from 'ws';
 
-import { getNodeRedAuthHeader } from '../utils/auth.js';
+import { resolveNodeRedAuthHeader } from '../utils/auth.js';
 
 import { NodeErrorChecker } from './node-error-checker.js';
 import { NodeRedAPIClient } from './nodered-api.js';
 
 vi.mock('../utils/auth.js', () => ({
-  getNodeRedAuthHeader: vi.fn().mockReturnValue({}),
+  resolveNodeRedAuthHeader: vi.fn().mockResolvedValue({}),
   getTlsRejectUnauthorized: vi.fn().mockReturnValue(true),
 }));
 
@@ -53,7 +53,7 @@ describe('NodeErrorChecker', () => {
   beforeEach(() => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    vi.mocked(getNodeRedAuthHeader).mockReturnValue({});
+    vi.mocked(resolveNodeRedAuthHeader).mockResolvedValue({});
   });
 
   afterEach(() => {

--- a/src/services/node-error-checker.ts
+++ b/src/services/node-error-checker.ts
@@ -1,6 +1,6 @@
 import WebSocket from 'ws';
 
-import { getNodeRedAuthHeader, getTlsRejectUnauthorized } from '../utils/auth.js';
+import { resolveNodeRedAuthHeader, getTlsRejectUnauthorized } from '../utils/auth.js';
 import { AuthenticationError } from '../utils/error-handling.js';
 
 import { NodeRedAPIClient } from './nodered-api.js';
@@ -26,10 +26,12 @@ interface RawStatus {
   text?: string;
 }
 
-function collectStatuses(
+async function collectStatuses(
   wsUrl: string,
   timeoutMs: number
 ): Promise<{ statuses: Map<string, RawStatus>; connected: boolean }> {
+  const headers = await resolveNodeRedAuthHeader();
+
   return new Promise((resolve, reject) => {
     const statuses = new Map<string, RawStatus>();
     let ws: WebSocket | null = null;
@@ -50,7 +52,7 @@ function collectStatuses(
     try {
       ws = new WebSocket(wsUrl, {
         rejectUnauthorized: getTlsRejectUnauthorized(),
-        headers: getNodeRedAuthHeader(),
+        headers,
       });
     } catch (err) {
       clearTimeout(timer);

--- a/src/services/node-error-checker.ts
+++ b/src/services/node-error-checker.ts
@@ -1,6 +1,10 @@
 import WebSocket from 'ws';
 
-import { resolveNodeRedAuthHeader, getTlsRejectUnauthorized } from '../utils/auth.js';
+import {
+  resolveNodeRedAuthHeader,
+  resolveNodeRedAuthToken,
+  getTlsRejectUnauthorized,
+} from '../utils/auth.js';
 import { AuthenticationError } from '../utils/error-handling.js';
 
 import { NodeRedAPIClient } from './nodered-api.js';
@@ -26,17 +30,33 @@ interface RawStatus {
   text?: string;
 }
 
+interface CommsFrame {
+  topic?: string;
+  data?: any;
+  auth?: 'ok' | 'fail';
+}
+
 async function collectStatuses(
   wsUrl: string,
   timeoutMs: number
-): Promise<{ statuses: Map<string, RawStatus>; connected: boolean }> {
-  const headers = await resolveNodeRedAuthHeader();
+): Promise<{
+  statuses: Map<string, RawStatus>;
+  connected: boolean;
+  authExpected: boolean;
+  authConfirmed: boolean;
+}> {
+  const [headers, token] = await Promise.all([
+    resolveNodeRedAuthHeader(),
+    resolveNodeRedAuthToken(),
+  ]);
+  const authExpected = token !== undefined;
 
   return new Promise((resolve, reject) => {
     const statuses = new Map<string, RawStatus>();
     let ws: WebSocket | null = null;
     let settled = false;
     let connected = false;
+    let authConfirmed = false;
 
     const finish = (err?: Error) => {
       if (settled) return;
@@ -44,7 +64,7 @@ async function collectStatuses(
       clearTimeout(timer);
       ws?.terminate();
       if (err) reject(err);
-      else resolve({ statuses, connected });
+      else resolve({ statuses, connected, authExpected, authConfirmed });
     };
 
     const timer = setTimeout(finish, timeoutMs);
@@ -52,6 +72,8 @@ async function collectStatuses(
     try {
       ws = new WebSocket(wsUrl, {
         rejectUnauthorized: getTlsRejectUnauthorized(),
+        // Still sent for a reverse proxy in front of Node-RED that gates the
+        // WS upgrade on it — Node-RED's own adminAuth ignores it, see below.
         headers,
       });
     } catch (err) {
@@ -62,34 +84,57 @@ async function collectStatuses(
 
     ws.on('open', () => {
       connected = true;
+      // Node-RED's /comms auth is entirely in-band, not header-based: send
+      // { auth: "<token>" } as the first message per Node-RED's own docs.
+      if (token) {
+        ws.send(JSON.stringify({ auth: token }));
+      }
     });
 
     ws.on('message', (raw: WebSocket.RawData) => {
       try {
         // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        const msg = JSON.parse(raw.toString()) as { topic: string; data?: any };
+        const parsed: unknown = JSON.parse(raw.toString());
+        // Node-RED batches multiple events into a JSON array per WS message;
+        // the auth handshake reply is always a single flat object.
+        const frames: CommsFrame[] = Array.isArray(parsed) ? parsed : [parsed];
 
-        if (msg.topic === 'auth') {
-          if (msg.data === 'fail') {
-            finish(new AuthenticationError('Node-RED WebSocket auth failed'));
+        for (const msg of frames) {
+          if (typeof msg.auth === 'string') {
+            if (msg.auth === 'ok') {
+              authConfirmed = true;
+            } else {
+              // Invalidate the cached token so the *next* check() call
+              // re-exchanges instead of retrying with the same bad token.
+              resolveNodeRedAuthToken(true).catch(() => {});
+              finish(new AuthenticationError('Node-RED WebSocket auth failed'));
+            }
+            continue;
           }
-          return;
-        }
 
-        if (msg.topic.startsWith('status/')) {
-          const nodeId = msg.topic.slice('status/'.length);
-          const d = (msg.data ?? {}) as Record<string, unknown>;
-          const fill = typeof d.fill === 'string' ? d.fill : undefined;
-          const shape = typeof d.shape === 'string' ? d.shape : undefined;
-          const text = typeof d.text === 'string' ? d.text : undefined;
-          if (!fill && !text) {
-            statuses.delete(nodeId);
-          } else {
-            const s: RawStatus = {};
-            if (fill !== undefined) s.fill = fill;
-            if (shape !== undefined) s.shape = shape;
-            if (text !== undefined) s.text = text;
-            statuses.set(nodeId, s);
+          if (typeof msg.topic !== 'string') continue;
+          // Any real event arriving is itself proof of authorization — an
+          // unauthenticated /comms connection receives nothing at all
+          // (confirmed empirically against a live instance). This covers
+          // NODERED_API_TOKEN setups where Node-RED never bothers to send
+          // an explicit { auth: "ok" } ack but still streams data.
+          authConfirmed = true;
+
+          if (msg.topic.startsWith('status/')) {
+            const nodeId = msg.topic.slice('status/'.length);
+            const d = (msg.data ?? {}) as Record<string, unknown>;
+            const fill = typeof d.fill === 'string' ? d.fill : undefined;
+            const shape = typeof d.shape === 'string' ? d.shape : undefined;
+            const text = typeof d.text === 'string' ? d.text : undefined;
+            if (!fill && !text) {
+              statuses.delete(nodeId);
+            } else {
+              const s: RawStatus = {};
+              if (fill !== undefined) s.fill = fill;
+              if (shape !== undefined) s.shape = shape;
+              if (text !== undefined) s.text = text;
+              statuses.set(nodeId, s);
+            }
           }
         }
       } catch {
@@ -114,7 +159,7 @@ export class NodeErrorChecker {
     const includeWarnings = opts.includeWarnings ?? false;
     const timeoutMs = Math.min(opts.timeoutMs ?? 2000, 30000);
 
-    const [{ statuses, connected }, flows] = await Promise.all([
+    const [{ statuses, connected, authExpected, authConfirmed }, flows] = await Promise.all([
       collectStatuses(this.apiClient.getCommsWsUrl(), timeoutMs),
       this.apiClient.getFlows().catch((): Awaited<ReturnType<NodeRedAPIClient['getFlows']>> => []),
     ]);
@@ -163,7 +208,7 @@ export class NodeErrorChecker {
     return {
       errors,
       warnings,
-      statusesMayBeIncomplete: !connected,
+      statusesMayBeIncomplete: !connected || (authExpected && !authConfirmed),
     };
   }
 }

--- a/src/services/node-error-checker.ts
+++ b/src/services/node-error-checker.ts
@@ -101,6 +101,17 @@ async function collectStatuses(
 
         for (const msg of frames) {
           if (typeof msg.auth === 'string') {
+            // Trusting the WebSocket peer's own auth-handshake reply is
+            // inherent to implementing Node-RED's documented /comms protocol
+            // — there is no alternative, signed proof Node-RED provides. The
+            // actual trust boundary is the TLS connection to NODERED_URL
+            // (see getTlsRejectUnauthorized), not this in-band message; a
+            // party able to inject frames on this socket without breaking
+            // TLS has already compromised the channel this check depends on.
+            // authConfirmed also only affects statusesMayBeIncomplete, a
+            // diagnostic-completeness signal — it grants no access, since
+            // the socket already receives whatever Node-RED sends regardless.
+            // codeql[js/user-controlled-bypass]
             if (msg.auth === 'ok') {
               authConfirmed = true;
             } else {

--- a/src/services/nodered-api.test.ts
+++ b/src/services/nodered-api.test.ts
@@ -32,12 +32,16 @@ import {
   mockAuthToken,
   mockAuthStatus,
 } from '../../test/fixtures/responses.js';
+import { resolveNodeRedAuthHeader } from '../utils/auth.js';
 
 import { NodeRedAPIClient } from './nodered-api.js';
 
 // Mock axios
 vi.mock('axios', () => {
-  const mockAxiosInstance = {
+  // Callable so tests can exercise `this.client(config)` retry calls made
+  // from inside the response interceptor's error handler.
+  const mockAxiosInstance: any = vi.fn();
+  Object.assign(mockAxiosInstance, {
     get: vi.fn(),
     post: vi.fn(),
     put: vi.fn(),
@@ -46,7 +50,7 @@ vi.mock('axios', () => {
       request: { use: vi.fn() },
       response: { use: vi.fn() },
     },
-  };
+  });
 
   return {
     default: {
@@ -59,7 +63,7 @@ vi.mock('axios', () => {
 
 // Mock auth utility
 vi.mock('../utils/auth.js', () => ({
-  getNodeRedAuthHeader: vi.fn(() => ({})),
+  resolveNodeRedAuthHeader: vi.fn(async () => ({})),
   getTlsRejectUnauthorized: vi.fn(() => true),
 }));
 
@@ -1135,6 +1139,83 @@ describe('NodeRedAPIClient', () => {
     it('getFlowSummaries propagates error from getFlows', async () => {
       mockAxiosInstance.get.mockRejectedValueOnce(err);
       await expect(client.getFlowSummaries()).rejects.toThrow();
+    });
+  });
+
+  describe('Auth header injection', () => {
+    it('applies resolveNodeRedAuthHeader on each request when there is no explicit auth override', async () => {
+      const requestInterceptor = mockAxiosInstance.interceptors.request.use.mock.calls[0][0];
+      const config: any = { headers: {} };
+
+      await requestInterceptor(config);
+
+      expect(resolveNodeRedAuthHeader).toHaveBeenCalledWith();
+    });
+
+    it('does not call resolveNodeRedAuthHeader when constructed with an explicit Authorization header (per-tenant client)', async () => {
+      vi.mocked(resolveNodeRedAuthHeader).mockClear();
+
+      new NodeRedAPIClient({
+        baseURL: 'http://tenant-nodered:1880',
+        headers: { Authorization: 'Bearer tenant-token' },
+      });
+      // The axios mock always returns the same shared instance object, so
+      // `.mock.calls` accumulates every client's registration — grab the
+      // most recent one (this test's tenant client), not index 0.
+      const requestCalls = mockAxiosInstance.interceptors.request.use.mock.calls;
+      const requestInterceptor = requestCalls[requestCalls.length - 1][0];
+
+      const config: any = { headers: { Authorization: 'Bearer tenant-token' } };
+      await requestInterceptor(config);
+
+      expect(resolveNodeRedAuthHeader).not.toHaveBeenCalled();
+      expect(config.headers.Authorization).toBe('Bearer tenant-token');
+    });
+  });
+
+  describe('401 handling', () => {
+    it('forces a token refresh and retries exactly once, guarded by _authRetry', async () => {
+      const responseErrorHandler = mockAxiosInstance.interceptors.response.use.mock.calls[0][1];
+      mockAxiosInstance.mockResolvedValueOnce({ data: 'retried-ok' });
+
+      const config: any = { headers: {}, _retryCount: 0 };
+      const error: any = { response: { status: 401 }, config };
+
+      const result = await responseErrorHandler(error);
+
+      expect(resolveNodeRedAuthHeader).toHaveBeenCalledWith(true);
+      expect(config._authRetry).toBe(true);
+      expect(mockAxiosInstance).toHaveBeenCalledTimes(1);
+      expect(mockAxiosInstance).toHaveBeenCalledWith(config);
+      expect(result).toEqual({ data: 'retried-ok' });
+    });
+
+    it('does not retry a second time once _authRetry is already set (no infinite loop)', async () => {
+      const responseErrorHandler = mockAxiosInstance.interceptors.response.use.mock.calls[0][1];
+      const config: any = { headers: {}, _authRetry: true, _retryCount: 3 };
+      const error: any = { response: { status: 401 }, config };
+
+      await expect(responseErrorHandler(error)).rejects.toBe(error);
+      expect(resolveNodeRedAuthHeader).not.toHaveBeenCalledWith(true);
+    });
+
+    it('skips forced refresh on 401 for a client with an explicit auth override (per-tenant client)', async () => {
+      const tenantClient = new NodeRedAPIClient({
+        baseURL: 'http://tenant-nodered:1880',
+        headers: { Authorization: 'Bearer tenant-token' },
+      });
+      // Same shared-mock caveat as above: grab the most recently registered
+      // response interceptor, which belongs to this test's tenant client.
+      const responseCalls = mockAxiosInstance.interceptors.response.use.mock.calls;
+      const responseErrorHandler = responseCalls[responseCalls.length - 1][1];
+      vi.mocked(resolveNodeRedAuthHeader).mockClear();
+
+      const config: any = { headers: {}, _retryCount: 3 };
+      const error: any = { response: { status: 401 }, config };
+
+      await expect(responseErrorHandler(error)).rejects.toBe(error);
+      expect(resolveNodeRedAuthHeader).not.toHaveBeenCalled();
+      expect(tenantClient).toBeDefined();
     });
   });
 });

--- a/src/services/nodered-api.test.ts
+++ b/src/services/nodered-api.test.ts
@@ -32,7 +32,11 @@ import {
   mockAuthToken,
   mockAuthStatus,
 } from '../../test/fixtures/responses.js';
-import { resolveNodeRedAuthHeader } from '../utils/auth.js';
+import {
+  resolveNodeRedAuthHeader,
+  isNodeRedAdminAuthEnabled,
+  validateNodeRedAuth,
+} from '../utils/auth.js';
 
 import { NodeRedAPIClient } from './nodered-api.js';
 
@@ -64,6 +68,8 @@ vi.mock('axios', () => {
 // Mock auth utility
 vi.mock('../utils/auth.js', () => ({
   resolveNodeRedAuthHeader: vi.fn(async () => ({})),
+  isNodeRedAdminAuthEnabled: vi.fn(() => true),
+  validateNodeRedAuth: vi.fn(() => ({ type: 'none' })),
   getTlsRejectUnauthorized: vi.fn(() => true),
 }));
 
@@ -1193,6 +1199,17 @@ describe('NodeRedAPIClient', () => {
     it('does not retry a second time once _authRetry is already set (no infinite loop)', async () => {
       const responseErrorHandler = mockAxiosInstance.interceptors.response.use.mock.calls[0][1];
       const config: any = { headers: {}, _authRetry: true, _retryCount: 3 };
+      const error: any = { response: { status: 401 }, config };
+
+      await expect(responseErrorHandler(error)).rejects.toBe(error);
+      expect(resolveNodeRedAuthHeader).not.toHaveBeenCalledWith(true);
+    });
+
+    it('skips the forced refresh when there is no refreshable auth (static Basic mode, gate off)', async () => {
+      vi.mocked(isNodeRedAdminAuthEnabled).mockReturnValueOnce(false);
+      vi.mocked(validateNodeRedAuth).mockReturnValueOnce({ type: 'basic' } as any);
+      const responseErrorHandler = mockAxiosInstance.interceptors.response.use.mock.calls[0][1];
+      const config: any = { headers: {}, _retryCount: 3 };
       const error: any = { response: { status: 401 }, config };
 
       await expect(responseErrorHandler(error)).rejects.toBe(error);

--- a/src/services/nodered-api.ts
+++ b/src/services/nodered-api.ts
@@ -18,7 +18,7 @@ import {
   NodeRedDeploymentOptions,
   NodeRedAPIError,
 } from '../types/nodered.js';
-import { getNodeRedAuthHeader, getTlsRejectUnauthorized } from '../utils/auth.js';
+import { resolveNodeRedAuthHeader, getTlsRejectUnauthorized } from '../utils/auth.js';
 import { handleNodeRedError } from '../utils/error-handling.js';
 import { CircuitBreaker, retryWithCircuitBreaker, type RetryOptions } from '../utils/retry.js';
 
@@ -59,6 +59,10 @@ export class NodeRedAPIClient {
   private config: NodeRedAPIConfig;
   private circuitBreaker: CircuitBreaker;
   private retryOptions: RetryOptions;
+  // True when this instance was constructed with an explicit Authorization
+  // header (e.g. per-tenant credentials from callToolPublic's OAuth path) —
+  // in that case the global-env auth resolver must never overwrite it.
+  private hasExplicitAuthOverride: boolean;
 
   constructor(config: Partial<NodeRedAPIConfig> = {}) {
     this.config = {
@@ -67,6 +71,7 @@ export class NodeRedAPIClient {
       retries: parseInt(process.env.NODERED_RETRIES || '3'),
       ...config,
     };
+    this.hasExplicitAuthOverride = Boolean(this.config.headers?.Authorization);
 
     // Initialize circuit breaker
     this.circuitBreaker = new CircuitBreaker({
@@ -109,7 +114,6 @@ export class NodeRedAPIClient {
       httpsAgent: new https.Agent({ rejectUnauthorized: getTlsRejectUnauthorized() }),
       headers: {
         'Content-Type': 'application/json',
-        ...getNodeRedAuthHeader(),
         ...this.config.headers,
       },
     });
@@ -151,7 +155,12 @@ export class NodeRedAPIClient {
    */
   private setupInterceptors(): void {
     this.client.interceptors.request.use(
-      config => config,
+      async config => {
+        if (!this.hasExplicitAuthOverride) {
+          Object.assign(config.headers, await resolveNodeRedAuthHeader());
+        }
+        return config;
+      },
       error => Promise.reject(error)
     );
 
@@ -181,6 +190,15 @@ export class NodeRedAPIClient {
       },
       async error => {
         const config = error.config;
+
+        if (error.response?.status === 401 && !config._authRetry && !this.hasExplicitAuthOverride) {
+          config._authRetry = true;
+          // Force a fresh token now; the request interceptor will also call
+          // resolveNodeRedAuthHeader() on the retry below, but that's a cache
+          // hit against what we just fetched, not a second network call.
+          await resolveNodeRedAuthHeader(true);
+          return this.client(config);
+        }
 
         if (!config._retry && config._retryCount < this.config.retries) {
           config._retry = true;

--- a/src/services/nodered-api.ts
+++ b/src/services/nodered-api.ts
@@ -18,7 +18,12 @@ import {
   NodeRedDeploymentOptions,
   NodeRedAPIError,
 } from '../types/nodered.js';
-import { resolveNodeRedAuthHeader, getTlsRejectUnauthorized } from '../utils/auth.js';
+import {
+  resolveNodeRedAuthHeader,
+  isNodeRedAdminAuthEnabled,
+  validateNodeRedAuth,
+  getTlsRejectUnauthorized,
+} from '../utils/auth.js';
 import { handleNodeRedError } from '../utils/error-handling.js';
 import { CircuitBreaker, retryWithCircuitBreaker, type RetryOptions } from '../utils/retry.js';
 
@@ -191,7 +196,15 @@ export class NodeRedAPIClient {
       async error => {
         const config = error.config;
 
-        if (error.response?.status === 401 && !config._authRetry && !this.hasExplicitAuthOverride) {
+        const hasRefreshableAuth =
+          isNodeRedAdminAuthEnabled() || validateNodeRedAuth().type === 'bearer';
+
+        if (
+          error.response?.status === 401 &&
+          !config._authRetry &&
+          !this.hasExplicitAuthOverride &&
+          hasRefreshableAuth
+        ) {
           config._authRetry = true;
           // Force a fresh token now; the request interceptor will also call
           // resolveNodeRedAuthHeader() on the retry below, but that's a cache

--- a/src/services/nodered-ws-client.test.ts
+++ b/src/services/nodered-ws-client.test.ts
@@ -8,13 +8,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { WebSocketServer, WebSocket } from 'ws';
 
 import { SSEHandler } from '../server/sse-handler.js';
-import { resolveNodeRedAuthHeader } from '../utils/auth.js';
+import { resolveNodeRedAuthHeader, resolveNodeRedAuthToken } from '../utils/auth.js';
 
 import { NodeRedWsClient } from './nodered-ws-client.js';
 
-// Silence auth util so we control what headers are returned
+// Silence auth util so we control what headers/token are returned
 vi.mock('../utils/auth.js', () => ({
   resolveNodeRedAuthHeader: vi.fn().mockResolvedValue({}),
+  resolveNodeRedAuthToken: vi.fn().mockResolvedValue(undefined),
   getTlsRejectUnauthorized: vi.fn().mockReturnValue(true),
 }));
 
@@ -49,6 +50,7 @@ describe('NodeRedWsClient', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
     // mockReset (vitest.config) clears return values between tests; restore default.
     vi.mocked(resolveNodeRedAuthHeader).mockResolvedValue({});
+    vi.mocked(resolveNodeRedAuthToken).mockResolvedValue(undefined);
     mockSSE = makeSSEHandler();
   });
 
@@ -253,6 +255,157 @@ describe('NodeRedWsClient', () => {
     await new Promise(r => setTimeout(r, 50));
     // Should not throw — broadcast may or may not be called for malformed input
     expect(client.isConnected()).toBe(true);
+
+    client.disconnect();
+    await close();
+  });
+
+  it('sends { auth: token } as the first message when a token is available', async () => {
+    vi.mocked(resolveNodeRedAuthToken).mockResolvedValue('some-token');
+
+    const { wss, port, close } = await startWsServer();
+    const client = new NodeRedWsClient(mockSSE as unknown as SSEHandler, {
+      baseURL: `http://localhost:${port}`,
+    });
+
+    let firstMessage: string | undefined;
+    await new Promise<void>(resolve => {
+      wss.once('connection', (ws: WebSocket) => {
+        ws.once('message', raw => {
+          // eslint-disable-next-line @typescript-eslint/no-base-to-string
+          firstMessage = raw.toString();
+          resolve();
+        });
+      });
+      client.connect();
+    });
+
+    expect(JSON.parse(firstMessage!)).toEqual({ auth: 'some-token' });
+
+    client.disconnect();
+    await close();
+  });
+
+  it('sends no auth message when no token is available', async () => {
+    const { wss, port, close } = await startWsServer();
+    const client = new NodeRedWsClient(mockSSE as unknown as SSEHandler, {
+      baseURL: `http://localhost:${port}`,
+    });
+
+    let receivedAnyMessage = false;
+    await new Promise<void>(resolve => {
+      wss.once('connection', (ws: WebSocket) => {
+        ws.once('message', () => {
+          receivedAnyMessage = true;
+        });
+        setTimeout(resolve, 50);
+      });
+      client.connect();
+    });
+
+    expect(receivedAnyMessage).toBe(false);
+
+    client.disconnect();
+    await close();
+  });
+
+  it('handles { auth: "ok" } / { auth: "fail" } handshake replies without broadcasting or throwing', async () => {
+    const { wss, port, close } = await startWsServer();
+    const client = new NodeRedWsClient(mockSSE as unknown as SSEHandler, {
+      baseURL: `http://localhost:${port}`,
+    });
+
+    await new Promise<void>(resolve => {
+      wss.once('connection', (ws: WebSocket) => {
+        ws.send(JSON.stringify({ auth: 'ok' }));
+        ws.send(JSON.stringify({ auth: 'fail' }));
+        setTimeout(resolve, 30);
+      });
+      client.connect();
+    });
+
+    expect(mockSSE.broadcast).not.toHaveBeenCalled();
+    expect(client.isConnected()).toBe(true);
+
+    client.disconnect();
+    await close();
+  });
+
+  it('ignores a well-formed frame with neither topic nor auth', async () => {
+    const { wss, port, close } = await startWsServer();
+    const client = new NodeRedWsClient(mockSSE as unknown as SSEHandler, {
+      baseURL: `http://localhost:${port}`,
+    });
+
+    await new Promise<void>(resolve => {
+      wss.once('connection', (ws: WebSocket) => {
+        ws.send(JSON.stringify({ unrelated: true }));
+        setTimeout(resolve, 30);
+      });
+      client.connect();
+    });
+
+    expect(mockSSE.broadcast).not.toHaveBeenCalled();
+    expect(client.isConnected()).toBe(true);
+
+    client.disconnect();
+    await close();
+  });
+
+  it('handles a batched array of events in a single WS message', async () => {
+    const { wss, port, close } = await startWsServer();
+    const client = new NodeRedWsClient(mockSSE as unknown as SSEHandler, {
+      baseURL: `http://localhost:${port}`,
+    });
+
+    await new Promise<void>(resolve => {
+      wss.once('connection', (ws: WebSocket) => {
+        ws.send(
+          JSON.stringify([
+            { topic: 'status/node-a', data: { fill: 'green', text: 'ok' } },
+            { topic: 'status/node-b', data: { fill: 'red', text: 'bad' } },
+          ])
+        );
+        setTimeout(resolve, 30);
+      });
+      client.connect();
+    });
+
+    expect(mockSSE.broadcast).toHaveBeenCalledTimes(2);
+
+    client.disconnect();
+    await close();
+  });
+
+  it('forces a token refresh on the next connect attempt after an auth failure', async () => {
+    vi.mocked(resolveNodeRedAuthToken).mockResolvedValue('some-token');
+
+    const { wss, port, close } = await startWsServer();
+    const client = new NodeRedWsClient(mockSSE as unknown as SSEHandler, {
+      baseURL: `http://localhost:${port}`,
+      maxReconnectDelay: 50,
+    });
+
+    await new Promise<void>(resolve => {
+      wss.once('connection', (ws: WebSocket) => {
+        ws.send(JSON.stringify({ auth: 'fail' }));
+        // Real Node-RED closes the socket on auth failure; do the same here
+        // so the client's reconnect path actually runs.
+        setTimeout(() => ws.close(), 10);
+        resolve();
+      });
+      client.connect();
+    });
+
+    // The first scheduled reconnect always waits 1000ms regardless of
+    // maxReconnectDelay (see NodeRedWsClient's reconnectDelay reset) — wait
+    // past that for _connect() to run again.
+    await new Promise(r => setTimeout(r, 1200));
+
+    const forceRefreshCalls = vi
+      .mocked(resolveNodeRedAuthToken)
+      .mock.calls.filter(call => call[0] === true);
+    expect(forceRefreshCalls.length).toBeGreaterThan(0);
 
     client.disconnect();
     await close();

--- a/src/services/nodered-ws-client.test.ts
+++ b/src/services/nodered-ws-client.test.ts
@@ -8,13 +8,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { WebSocketServer, WebSocket } from 'ws';
 
 import { SSEHandler } from '../server/sse-handler.js';
-import { getNodeRedAuthHeader } from '../utils/auth.js';
+import { resolveNodeRedAuthHeader } from '../utils/auth.js';
 
 import { NodeRedWsClient } from './nodered-ws-client.js';
 
 // Silence auth util so we control what headers are returned
 vi.mock('../utils/auth.js', () => ({
-  getNodeRedAuthHeader: vi.fn().mockReturnValue({}),
+  resolveNodeRedAuthHeader: vi.fn().mockResolvedValue({}),
   getTlsRejectUnauthorized: vi.fn().mockReturnValue(true),
 }));
 
@@ -48,7 +48,7 @@ describe('NodeRedWsClient', () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
     // mockReset (vitest.config) clears return values between tests; restore default.
-    vi.mocked(getNodeRedAuthHeader).mockReturnValue({});
+    vi.mocked(resolveNodeRedAuthHeader).mockResolvedValue({});
     mockSSE = makeSSEHandler();
   });
 
@@ -192,9 +192,9 @@ describe('NodeRedWsClient', () => {
     await close();
   });
 
-  it('passes auth headers in WS handshake when Basic auth is configured', async () => {
-    vi.mocked(getNodeRedAuthHeader).mockReturnValue({
-      Authorization: 'Basic dXNlcjpwYXNz',
+  it('passes resolved auth headers through to the WS handshake', async () => {
+    vi.mocked(resolveNodeRedAuthHeader).mockResolvedValue({
+      Authorization: 'Bearer some-token',
     });
 
     const { wss, port, close } = await startWsServer();
@@ -211,8 +211,8 @@ describe('NodeRedWsClient', () => {
       client.connect();
     });
 
-    expect(receivedAuthHeader).toBe('Basic dXNlcjpwYXNz');
-    expect(getNodeRedAuthHeader).toHaveBeenCalled();
+    expect(receivedAuthHeader).toBe('Bearer some-token');
+    expect(resolveNodeRedAuthHeader).toHaveBeenCalled();
 
     client.disconnect();
     await close();

--- a/src/services/nodered-ws-client.ts
+++ b/src/services/nodered-ws-client.ts
@@ -12,7 +12,7 @@ import {
   NodeRedRuntimeEvent,
   NodeRedStatusEvent,
 } from '../types/nodered.js';
-import { getNodeRedAuthHeader, getTlsRejectUnauthorized } from '../utils/auth.js';
+import { resolveNodeRedAuthHeader, getTlsRejectUnauthorized } from '../utils/auth.js';
 
 export interface NodeRedWsConfig {
   baseURL: string;
@@ -46,10 +46,10 @@ export class NodeRedWsClient {
   connect(): void {
     this.stopped = false;
     this.reconnectDelay = 1000;
-    this._connect();
+    void this._connect();
   }
 
-  private _connect(): void {
+  private async _connect(): Promise<void> {
     if (this.stopped) return;
 
     if (this.ws) {
@@ -63,9 +63,10 @@ export class NodeRedWsClient {
       .replace(/\/$/, '')}/comms`;
 
     try {
+      const headers = await resolveNodeRedAuthHeader();
       this.ws = new WebSocket(wsUrl, {
         rejectUnauthorized: getTlsRejectUnauthorized(),
-        headers: getNodeRedAuthHeader(),
+        headers,
       });
     } catch (err) {
       console.error('NodeRedWsClient: failed to create WebSocket', err);
@@ -107,7 +108,7 @@ export class NodeRedWsClient {
     if (this.stopped) return;
     const delay = this.reconnectDelay;
     this.reconnectDelay = Math.min(this.reconnectDelay * 2, this.maxReconnectDelay);
-    this.reconnectTimer = setTimeout(() => this._connect(), delay);
+    this.reconnectTimer = setTimeout(() => void this._connect(), delay);
   }
 
   private _handleMessage(msg: CommsMessage): void {

--- a/src/services/nodered-ws-client.ts
+++ b/src/services/nodered-ws-client.ts
@@ -12,7 +12,11 @@ import {
   NodeRedRuntimeEvent,
   NodeRedStatusEvent,
 } from '../types/nodered.js';
-import { resolveNodeRedAuthHeader, getTlsRejectUnauthorized } from '../utils/auth.js';
+import {
+  resolveNodeRedAuthHeader,
+  resolveNodeRedAuthToken,
+  getTlsRejectUnauthorized,
+} from '../utils/auth.js';
 
 export interface NodeRedWsConfig {
   baseURL: string;
@@ -20,9 +24,15 @@ export interface NodeRedWsConfig {
   onEvent?: () => void;
 }
 
+// Node-RED's own /comms wire format: the auth handshake reply is a flat
+// { auth: 'ok' | 'fail' } object; every other frame is a { topic, data }
+// event, and Node-RED batches multiple events into a JSON array per message
+// (confirmed against a live instance — a single inject can produce a
+// two-element array in one WebSocket message).
 interface CommsMessage {
-  topic: string;
+  topic?: string;
   data?: any;
+  auth?: 'ok' | 'fail';
 }
 
 export class NodeRedWsClient {
@@ -35,6 +45,10 @@ export class NodeRedWsClient {
   private connected = false;
   private stopped = false;
   private onEvent?: () => void;
+  // Set when Node-RED's in-band /comms handshake rejects our token, cleared
+  // on a successful handshake — forces a fresh token on the next reconnect
+  // instead of retrying with the same one forever.
+  private authFailedLastAttempt = false;
 
   constructor(sseHandler: SSEHandler, config: NodeRedWsConfig) {
     this.sseHandler = sseHandler;
@@ -62,10 +76,19 @@ export class NodeRedWsClient {
       .replace(/^http:\/\//, 'ws://')
       .replace(/\/$/, '')}/comms`;
 
+    let token: string | undefined;
     try {
-      const headers = await resolveNodeRedAuthHeader();
+      const forceRefresh = this.authFailedLastAttempt;
+      const [headers, resolvedToken] = await Promise.all([
+        resolveNodeRedAuthHeader(forceRefresh),
+        resolveNodeRedAuthToken(forceRefresh),
+      ]);
+      token = resolvedToken;
       this.ws = new WebSocket(wsUrl, {
         rejectUnauthorized: getTlsRejectUnauthorized(),
+        // Still sent even though Node-RED's own adminAuth ignores headers on
+        // this endpoint — a reverse proxy in front of Node-RED may still
+        // gate the WS upgrade request on it.
         headers,
       });
     } catch (err) {
@@ -78,13 +101,24 @@ export class NodeRedWsClient {
       this.connected = true;
       this.reconnectDelay = 1000;
       console.log(`NodeRedWsClient: connected to ${wsUrl}`);
+      // Node-RED's /comms auth is entirely in-band: the connection headers
+      // above do nothing for Node-RED's own adminAuth. Per Node-RED's docs,
+      // the client must send { auth: "<token>" } as its first message.
+      if (token) {
+        this.ws!.send(JSON.stringify({ auth: token }));
+      }
     });
 
     this.ws.on('message', (raw: WebSocket.RawData) => {
       try {
         // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        const msg: CommsMessage = JSON.parse(raw.toString());
-        this._handleMessage(msg);
+        const parsed: unknown = JSON.parse(raw.toString());
+        // Node-RED batches multiple events into a JSON array per WS message;
+        // the auth handshake reply is always a single flat object.
+        const frames: CommsMessage[] = Array.isArray(parsed) ? parsed : [parsed];
+        for (const msg of frames) {
+          this._handleMessage(msg);
+        }
       } catch {
         // ignore malformed frames
       }
@@ -113,17 +147,21 @@ export class NodeRedWsClient {
 
   private _handleMessage(msg: CommsMessage): void {
     this.onEvent?.();
-    const { topic, data } = msg;
-    const timestamp = new Date().toISOString();
 
-    if (topic === 'auth') {
-      if (data === 'ok') {
+    if (typeof msg.auth === 'string') {
+      if (msg.auth === 'ok') {
+        this.authFailedLastAttempt = false;
         console.log('NodeRedWsClient: auth ok');
-      } else if (data === 'fail') {
+      } else {
+        this.authFailedLastAttempt = true;
         console.error('NodeRedWsClient: auth failed');
       }
       return;
     }
+
+    if (typeof msg.topic !== 'string') return;
+    const { topic, data } = msg;
+    const timestamp = new Date().toISOString();
 
     if (topic.startsWith('status/')) {
       const nodeId = topic.slice('status/'.length);

--- a/src/services/nodered-ws-client.ts
+++ b/src/services/nodered-ws-client.ts
@@ -149,6 +149,11 @@ export class NodeRedWsClient {
     this.onEvent?.();
 
     if (typeof msg.auth === 'string') {
+      // Trusting the peer's own auth-handshake reply is inherent to
+      // implementing Node-RED's /comms protocol; the real trust boundary is
+      // the TLS connection to NODERED_URL (getTlsRejectUnauthorized), not
+      // this in-band message. This flag only decides whether the *next*
+      // reconnect forces a token refresh — it grants no access itself.
       if (msg.auth === 'ok') {
         this.authFailedLastAttempt = false;
         console.log('NodeRedWsClient: auth ok');

--- a/src/utils/auth.test.ts
+++ b/src/utils/auth.test.ts
@@ -696,6 +696,7 @@ describe('resolveNodeRedAuthHeader', () => {
   // Each test re-imports the module fresh (via resetModules) so the
   // in-memory token cache doesn't leak between tests.
   beforeEach(() => {
+    vi.clearAllMocks();
     vi.resetModules();
     delete process.env.NODERED_USERNAME;
     delete process.env.NODERED_PASSWORD;
@@ -734,6 +735,43 @@ describe('resolveNodeRedAuthHeader', () => {
       expect.objectContaining({ grant_type: 'password', username: 'admin', password: 'secret' }),
       expect.anything()
     );
+  });
+
+  it('strips a trailing slash from NODERED_URL before building the token endpoint', async () => {
+    process.env.NODERED_USERNAME = 'admin';
+    process.env.NODERED_PASSWORD = 'secret';
+    process.env.NODERED_URL = 'http://localhost:1880/';
+    const axios = (await import('axios')).default;
+    vi.mocked(axios.post).mockResolvedValue({
+      data: { access_token: 'tok-1', expires_in: 3600 },
+    });
+    const { resolveNodeRedAuthHeader } = await import('./auth.js');
+
+    await resolveNodeRedAuthHeader();
+
+    expect(axios.post).toHaveBeenCalledWith(
+      'http://localhost:1880/auth/token',
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('clamps the cache TTL to a floor instead of going negative for a short-lived token', async () => {
+    process.env.NODERED_USERNAME = 'admin';
+    process.env.NODERED_PASSWORD = 'secret';
+    const axios = (await import('axios')).default;
+    // expires_in shorter than the 60s safety buffer would otherwise make
+    // the computed expiry land in the past, forcing a re-exchange on every
+    // single call instead of caching at all.
+    vi.mocked(axios.post).mockResolvedValue({
+      data: { access_token: 'tok-1', expires_in: 10 },
+    });
+    const { resolveNodeRedAuthHeader } = await import('./auth.js');
+
+    await resolveNodeRedAuthHeader();
+    await resolveNodeRedAuthHeader();
+
+    expect(axios.post).toHaveBeenCalledTimes(1);
   });
 
   it('forceRefresh bypasses the cache and re-exchanges credentials', async () => {

--- a/src/utils/auth.test.ts
+++ b/src/utils/auth.test.ts
@@ -701,6 +701,7 @@ describe('resolveNodeRedAuthHeader', () => {
     delete process.env.NODERED_USERNAME;
     delete process.env.NODERED_PASSWORD;
     delete process.env.NODERED_API_TOKEN;
+    delete process.env.NODERED_ADMIN_AUTH_ENABLED;
     process.env.NODERED_URL = 'http://localhost:1880';
   });
 
@@ -718,6 +719,7 @@ describe('resolveNodeRedAuthHeader', () => {
   it('exchanges username/password for a bearer token and caches it', async () => {
     process.env.NODERED_USERNAME = 'admin';
     process.env.NODERED_PASSWORD = 'secret';
+    process.env.NODERED_ADMIN_AUTH_ENABLED = 'true';
     const axios = (await import('axios')).default;
     vi.mocked(axios.post).mockResolvedValue({
       data: { access_token: 'tok-1', expires_in: 3600 },
@@ -740,6 +742,7 @@ describe('resolveNodeRedAuthHeader', () => {
   it('strips a trailing slash from NODERED_URL before building the token endpoint', async () => {
     process.env.NODERED_USERNAME = 'admin';
     process.env.NODERED_PASSWORD = 'secret';
+    process.env.NODERED_ADMIN_AUTH_ENABLED = 'true';
     process.env.NODERED_URL = 'http://localhost:1880/';
     const axios = (await import('axios')).default;
     vi.mocked(axios.post).mockResolvedValue({
@@ -759,6 +762,7 @@ describe('resolveNodeRedAuthHeader', () => {
   it('clamps the cache TTL to a floor instead of going negative for a short-lived token', async () => {
     process.env.NODERED_USERNAME = 'admin';
     process.env.NODERED_PASSWORD = 'secret';
+    process.env.NODERED_ADMIN_AUTH_ENABLED = 'true';
     const axios = (await import('axios')).default;
     // expires_in shorter than the 60s safety buffer would otherwise make
     // the computed expiry land in the past, forcing a re-exchange on every
@@ -777,6 +781,7 @@ describe('resolveNodeRedAuthHeader', () => {
   it('forceRefresh bypasses the cache and re-exchanges credentials', async () => {
     process.env.NODERED_USERNAME = 'admin';
     process.env.NODERED_PASSWORD = 'secret';
+    process.env.NODERED_ADMIN_AUTH_ENABLED = 'true';
     const axios = (await import('axios')).default;
     vi.mocked(axios.post)
       .mockResolvedValueOnce({ data: { access_token: 'tok-1', expires_in: 3600 } })
@@ -793,6 +798,7 @@ describe('resolveNodeRedAuthHeader', () => {
   it('dedupes concurrent calls into a single token exchange', async () => {
     process.env.NODERED_USERNAME = 'admin';
     process.env.NODERED_PASSWORD = 'secret';
+    process.env.NODERED_ADMIN_AUTH_ENABLED = 'true';
     const axios = (await import('axios')).default;
     let resolvePost!: (value: { data: { access_token: string; expires_in: number } }) => void;
     vi.mocked(axios.post).mockReturnValue(
@@ -811,5 +817,135 @@ describe('resolveNodeRedAuthHeader', () => {
     expect(r1).toEqual({ Authorization: 'Bearer tok-1' });
     expect(r2).toEqual({ Authorization: 'Bearer tok-1' });
     expect(axios.post).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a static Basic header when the admin-auth gate is off (default)', async () => {
+    process.env.NODERED_USERNAME = 'admin';
+    process.env.NODERED_PASSWORD = 'secret';
+    // NODERED_ADMIN_AUTH_ENABLED deliberately left unset.
+    const axios = (await import('axios')).default;
+    const { resolveNodeRedAuthHeader } = await import('./auth.js');
+
+    const header = await resolveNodeRedAuthHeader();
+
+    expect(header.Authorization).toBe(`Basic ${Buffer.from('admin:secret').toString('base64')}`);
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a static Basic header when the gate is literally "false"', async () => {
+    process.env.NODERED_USERNAME = 'admin';
+    process.env.NODERED_PASSWORD = 'secret';
+    process.env.NODERED_ADMIN_AUTH_ENABLED = 'false';
+    const axios = (await import('axios')).default;
+    const { resolveNodeRedAuthHeader } = await import('./auth.js');
+
+    const header = await resolveNodeRedAuthHeader();
+
+    expect(header.Authorization).toBe(`Basic ${Buffer.from('admin:secret').toString('base64')}`);
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  it('bearer mode (NODERED_API_TOKEN) is unaffected by the gate being off', async () => {
+    process.env.NODERED_API_TOKEN = 'static-token';
+    const axios = (await import('axios')).default;
+    const { resolveNodeRedAuthHeader } = await import('./auth.js');
+
+    const header = await resolveNodeRedAuthHeader();
+
+    expect(header).toEqual({ Authorization: 'Bearer static-token' });
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+});
+
+describe('isNodeRedAdminAuthEnabled', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.NODERED_ADMIN_AUTH_ENABLED;
+  });
+
+  it('is false when unset', async () => {
+    const { isNodeRedAdminAuthEnabled } = await import('./auth.js');
+    expect(isNodeRedAdminAuthEnabled()).toBe(false);
+  });
+
+  it('is false for any value other than the literal string "true"', async () => {
+    process.env.NODERED_ADMIN_AUTH_ENABLED = 'false';
+    const { isNodeRedAdminAuthEnabled } = await import('./auth.js');
+    expect(isNodeRedAdminAuthEnabled()).toBe(false);
+  });
+
+  it('is true when set to "true"', async () => {
+    process.env.NODERED_ADMIN_AUTH_ENABLED = 'true';
+    const { isNodeRedAdminAuthEnabled } = await import('./auth.js');
+    expect(isNodeRedAdminAuthEnabled()).toBe(true);
+  });
+});
+
+describe('resolveNodeRedAuthToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    delete process.env.NODERED_USERNAME;
+    delete process.env.NODERED_PASSWORD;
+    delete process.env.NODERED_API_TOKEN;
+    delete process.env.NODERED_ADMIN_AUTH_ENABLED;
+    process.env.NODERED_URL = 'http://localhost:1880';
+  });
+
+  it('returns the token directly in bearer mode', async () => {
+    process.env.NODERED_API_TOKEN = 'static-token';
+    const { resolveNodeRedAuthToken } = await import('./auth.js');
+
+    expect(await resolveNodeRedAuthToken()).toBe('static-token');
+  });
+
+  it('returns undefined in basic mode when the gate is off', async () => {
+    process.env.NODERED_USERNAME = 'admin';
+    process.env.NODERED_PASSWORD = 'secret';
+    const axios = (await import('axios')).default;
+    const { resolveNodeRedAuthToken } = await import('./auth.js');
+
+    expect(await resolveNodeRedAuthToken()).toBeUndefined();
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when no credentials are configured', async () => {
+    const { resolveNodeRedAuthToken } = await import('./auth.js');
+    expect(await resolveNodeRedAuthToken()).toBeUndefined();
+  });
+
+  it('exchanges and returns the token in basic mode when the gate is on, sharing the cache with resolveNodeRedAuthHeader', async () => {
+    process.env.NODERED_USERNAME = 'admin';
+    process.env.NODERED_PASSWORD = 'secret';
+    process.env.NODERED_ADMIN_AUTH_ENABLED = 'true';
+    const axios = (await import('axios')).default;
+    vi.mocked(axios.post).mockResolvedValue({
+      data: { access_token: 'tok-1', expires_in: 3600 },
+    });
+    const { resolveNodeRedAuthToken, resolveNodeRedAuthHeader } = await import('./auth.js');
+
+    const token = await resolveNodeRedAuthToken();
+    const header = await resolveNodeRedAuthHeader();
+
+    expect(token).toBe('tok-1');
+    expect(header).toEqual({ Authorization: 'Bearer tok-1' });
+    expect(axios.post).toHaveBeenCalledTimes(1);
+  });
+
+  it('forceRefresh re-exchanges the token', async () => {
+    process.env.NODERED_USERNAME = 'admin';
+    process.env.NODERED_PASSWORD = 'secret';
+    process.env.NODERED_ADMIN_AUTH_ENABLED = 'true';
+    const axios = (await import('axios')).default;
+    vi.mocked(axios.post)
+      .mockResolvedValueOnce({ data: { access_token: 'tok-1', expires_in: 3600 } })
+      .mockResolvedValueOnce({ data: { access_token: 'tok-2', expires_in: 3600 } });
+    const { resolveNodeRedAuthToken } = await import('./auth.js');
+
+    await resolveNodeRedAuthToken();
+    const refreshed = await resolveNodeRedAuthToken(true);
+
+    expect(refreshed).toBe('tok-2');
+    expect(axios.post).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/utils/auth.test.ts
+++ b/src/utils/auth.test.ts
@@ -4,7 +4,7 @@
 
 import type { Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import type { McpAuthContext } from '../types/mcp-extensions.js';
 
@@ -25,6 +25,13 @@ import {
   type AuthPayload,
   type AuthRequest,
 } from './auth.js';
+
+vi.mock('axios', () => ({
+  default: {
+    post: vi.fn(),
+    isAxiosError: vi.fn(() => false),
+  },
+}));
 
 describe('Auth Utils', () => {
   const mockSecret = 'test-secret-key-minimum-32-chars-xxxx';
@@ -682,5 +689,89 @@ describe('Rate Limiting Utilities', () => {
 
       expect(key).toBe('ip:unknown');
     });
+  });
+});
+
+describe('resolveNodeRedAuthHeader', () => {
+  // Each test re-imports the module fresh (via resetModules) so the
+  // in-memory token cache doesn't leak between tests.
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.NODERED_USERNAME;
+    delete process.env.NODERED_PASSWORD;
+    delete process.env.NODERED_API_TOKEN;
+    process.env.NODERED_URL = 'http://localhost:1880';
+  });
+
+  it('passes NODERED_API_TOKEN through unchanged without hitting the network', async () => {
+    process.env.NODERED_API_TOKEN = 'static-token';
+    const axios = (await import('axios')).default;
+    const { resolveNodeRedAuthHeader } = await import('./auth.js');
+
+    const header = await resolveNodeRedAuthHeader();
+
+    expect(header).toEqual({ Authorization: 'Bearer static-token' });
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  it('exchanges username/password for a bearer token and caches it', async () => {
+    process.env.NODERED_USERNAME = 'admin';
+    process.env.NODERED_PASSWORD = 'secret';
+    const axios = (await import('axios')).default;
+    vi.mocked(axios.post).mockResolvedValue({
+      data: { access_token: 'tok-1', expires_in: 3600 },
+    });
+    const { resolveNodeRedAuthHeader } = await import('./auth.js');
+
+    const first = await resolveNodeRedAuthHeader();
+    const second = await resolveNodeRedAuthHeader();
+
+    expect(first).toEqual({ Authorization: 'Bearer tok-1' });
+    expect(second).toEqual({ Authorization: 'Bearer tok-1' });
+    expect(axios.post).toHaveBeenCalledTimes(1);
+    expect(axios.post).toHaveBeenCalledWith(
+      'http://localhost:1880/auth/token',
+      expect.objectContaining({ grant_type: 'password', username: 'admin', password: 'secret' }),
+      expect.anything()
+    );
+  });
+
+  it('forceRefresh bypasses the cache and re-exchanges credentials', async () => {
+    process.env.NODERED_USERNAME = 'admin';
+    process.env.NODERED_PASSWORD = 'secret';
+    const axios = (await import('axios')).default;
+    vi.mocked(axios.post)
+      .mockResolvedValueOnce({ data: { access_token: 'tok-1', expires_in: 3600 } })
+      .mockResolvedValueOnce({ data: { access_token: 'tok-2', expires_in: 3600 } });
+    const { resolveNodeRedAuthHeader } = await import('./auth.js');
+
+    await resolveNodeRedAuthHeader();
+    const refreshed = await resolveNodeRedAuthHeader(true);
+
+    expect(refreshed).toEqual({ Authorization: 'Bearer tok-2' });
+    expect(axios.post).toHaveBeenCalledTimes(2);
+  });
+
+  it('dedupes concurrent calls into a single token exchange', async () => {
+    process.env.NODERED_USERNAME = 'admin';
+    process.env.NODERED_PASSWORD = 'secret';
+    const axios = (await import('axios')).default;
+    let resolvePost!: (value: { data: { access_token: string; expires_in: number } }) => void;
+    vi.mocked(axios.post).mockReturnValue(
+      new Promise(resolve => {
+        resolvePost = resolve;
+      })
+    );
+    const { resolveNodeRedAuthHeader } = await import('./auth.js');
+
+    const call1 = resolveNodeRedAuthHeader();
+    const call2 = resolveNodeRedAuthHeader();
+    resolvePost({ data: { access_token: 'tok-1', expires_in: 3600 } });
+
+    const [r1, r2] = await Promise.all([call1, call2]);
+
+    expect(r1).toEqual({ Authorization: 'Bearer tok-1' });
+    expect(r2).toEqual({ Authorization: 'Bearer tok-1' });
+    expect(axios.post).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -3,7 +3,9 @@
  */
 
 import { timingSafeEqual } from 'crypto';
+import https from 'https';
 
+import axios from 'axios';
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 
@@ -337,6 +339,73 @@ export function getNodeRedAuthHeader(): Record<string, string> {
     default:
       return {};
   }
+}
+
+interface CachedNodeRedToken {
+  accessToken: string;
+  expiresAt: number; // ms epoch
+}
+
+let cachedNodeRedToken: CachedNodeRedToken | null = null;
+let nodeRedTokenFetch: Promise<CachedNodeRedToken> | null = null;
+
+async function fetchNodeRedToken(username: string, password: string): Promise<CachedNodeRedToken> {
+  const baseURL = process.env.NODERED_URL || 'http://localhost:1880';
+  const response = await axios.post(
+    `${baseURL}/auth/token`,
+    { client_id: 'node-red-admin', grant_type: 'password', scope: '*', username, password },
+    {
+      timeout: parseInt(process.env.NODERED_TIMEOUT || '5000'),
+      httpsAgent: new https.Agent({ rejectUnauthorized: getTlsRejectUnauthorized() }),
+    }
+  );
+  const { access_token, expires_in } = response.data;
+  // 60s safety buffer so we refresh slightly before Node-RED actually expires it
+  const ttlMs = (Number(expires_in) || 604800) * 1000 - 60_000;
+  return { accessToken: access_token, expiresAt: Date.now() + ttlMs };
+}
+
+/**
+ * Resolve a usable Authorization header for Node-RED.
+ *
+ * Node-RED's admin API only ever accepts a Bearer token (obtained via the
+ * /auth/token password-grant exchange) — it does NOT accept raw HTTP Basic
+ * auth. When NODERED_USERNAME/NODERED_PASSWORD are configured, this exchanges
+ * them for a token on demand and caches it in memory, transparently
+ * re-fetching a new one once it's close to expiry (or when `forceRefresh` is
+ * passed after a 401). Bearer (NODERED_API_TOKEN) and none modes pass through
+ * unchanged.
+ */
+export async function resolveNodeRedAuthHeader(
+  forceRefresh = false
+): Promise<Record<string, string>> {
+  const authConfig = validateNodeRedAuth();
+
+  if (authConfig.type === 'bearer') {
+    return { Authorization: `Bearer ${authConfig.credentials!.token}` };
+  }
+
+  if (authConfig.type !== 'basic') {
+    return {};
+  }
+
+  if (forceRefresh) {
+    cachedNodeRedToken = null;
+  }
+
+  if (cachedNodeRedToken && Date.now() < cachedNodeRedToken.expiresAt) {
+    return { Authorization: `Bearer ${cachedNodeRedToken.accessToken}` };
+  }
+
+  if (!nodeRedTokenFetch) {
+    const { username, password } = authConfig.credentials!;
+    nodeRedTokenFetch = fetchNodeRedToken(username!, password!).finally(() => {
+      nodeRedTokenFetch = null;
+    });
+  }
+
+  cachedNodeRedToken = await nodeRedTokenFetch;
+  return { Authorization: `Bearer ${cachedNodeRedToken.accessToken}` };
 }
 
 /**

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -350,7 +350,7 @@ let cachedNodeRedToken: CachedNodeRedToken | null = null;
 let nodeRedTokenFetch: Promise<CachedNodeRedToken> | null = null;
 
 async function fetchNodeRedToken(username: string, password: string): Promise<CachedNodeRedToken> {
-  const baseURL = process.env.NODERED_URL || 'http://localhost:1880';
+  const baseURL = (process.env.NODERED_URL || 'http://localhost:1880').replace(/\/+$/, '');
   const response = await axios.post(
     `${baseURL}/auth/token`,
     { client_id: 'node-red-admin', grant_type: 'password', scope: '*', username, password },
@@ -360,8 +360,11 @@ async function fetchNodeRedToken(username: string, password: string): Promise<Ca
     }
   );
   const { access_token, expires_in } = response.data;
-  // 60s safety buffer so we refresh slightly before Node-RED actually expires it
-  const ttlMs = (Number(expires_in) || 604800) * 1000 - 60_000;
+  const rawTtlMs = (Number(expires_in) || 604800) * 1000;
+  // 60s safety buffer so we refresh slightly before Node-RED actually expires
+  // it, but never below a 5s floor — a very short-lived expires_in would
+  // otherwise make ttlMs negative and force a re-exchange on every request.
+  const ttlMs = Math.max(rawTtlMs - 60_000, 5_000);
   return { accessToken: access_token, expiresAt: Date.now() + ttlMs };
 }
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -369,27 +369,37 @@ async function fetchNodeRedToken(username: string, password: string): Promise<Ca
 }
 
 /**
- * Resolve a usable Authorization header for Node-RED.
+ * When true, NODERED_USERNAME/NODERED_PASSWORD are exchanged for a Bearer
+ * token via Node-RED's own /auth/token endpoint — i.e. Node-RED's adminAuth
+ * is enabled and is the thing actually checking these credentials.
  *
- * Node-RED's admin API only ever accepts a Bearer token (obtained via the
- * /auth/token password-grant exchange) — it does NOT accept raw HTTP Basic
- * auth. When NODERED_USERNAME/NODERED_PASSWORD are configured, this exchanges
- * them for a token on demand and caches it in memory, transparently
- * re-fetching a new one once it's close to expiry (or when `forceRefresh` is
- * passed after a 401). Bearer (NODERED_API_TOKEN) and none modes pass through
- * unchanged.
+ * When false (default), those credentials are sent as a static HTTP Basic
+ * header on every request instead, via getNodeRedAuthHeader(). That's for
+ * deployments where NODERED_USERNAME/PASSWORD aren't Node-RED's own adminAuth
+ * at all, but credentials for a reverse proxy (nginx, Traefik, ...) sitting
+ * in front of the whole instance and Basic-auth-gating every request
+ * including the token endpoint itself — for that setup, doing the exchange
+ * would 401 immediately at the proxy, before ever reaching Node-RED.
  */
-export async function resolveNodeRedAuthHeader(
-  forceRefresh = false
-): Promise<Record<string, string>> {
+export function isNodeRedAdminAuthEnabled(): boolean {
+  return process.env.NODERED_ADMIN_AUTH_ENABLED === 'true';
+}
+
+/**
+ * Resolve a Bearer token for Node-RED, or undefined if none is available
+ * (basic mode with the exchange not opted into, or no credentials at all).
+ * Shared by resolveNodeRedAuthHeader and resolveNodeRedAuthToken so there's
+ * one cache and one exchange in flight at a time.
+ */
+async function resolveBearerToken(forceRefresh: boolean): Promise<string | undefined> {
   const authConfig = validateNodeRedAuth();
 
   if (authConfig.type === 'bearer') {
-    return { Authorization: `Bearer ${authConfig.credentials!.token}` };
+    return authConfig.credentials!.token;
   }
 
-  if (authConfig.type !== 'basic') {
-    return {};
+  if (authConfig.type !== 'basic' || !isNodeRedAdminAuthEnabled()) {
+    return undefined;
   }
 
   if (forceRefresh) {
@@ -397,7 +407,7 @@ export async function resolveNodeRedAuthHeader(
   }
 
   if (cachedNodeRedToken && Date.now() < cachedNodeRedToken.expiresAt) {
-    return { Authorization: `Bearer ${cachedNodeRedToken.accessToken}` };
+    return cachedNodeRedToken.accessToken;
   }
 
   if (!nodeRedTokenFetch) {
@@ -408,7 +418,38 @@ export async function resolveNodeRedAuthHeader(
   }
 
   cachedNodeRedToken = await nodeRedTokenFetch;
-  return { Authorization: `Bearer ${cachedNodeRedToken.accessToken}` };
+  return cachedNodeRedToken.accessToken;
+}
+
+/**
+ * Resolve a usable Authorization header for Node-RED's HTTP admin API.
+ *
+ * Bearer mode (NODERED_API_TOKEN) always uses that token directly. Basic mode
+ * (NODERED_USERNAME/PASSWORD) uses a Bearer token from the /auth/token
+ * exchange only when isNodeRedAdminAuthEnabled() is true; otherwise it falls
+ * back to a static HTTP Basic header via getNodeRedAuthHeader() (see that
+ * function's caveat: Node-RED's own admin API does not accept Basic auth, so
+ * this fallback path is only correct when the credentials are actually meant
+ * for something in front of Node-RED, not Node-RED's own adminAuth).
+ */
+export async function resolveNodeRedAuthHeader(
+  forceRefresh = false
+): Promise<Record<string, string>> {
+  const token = await resolveBearerToken(forceRefresh);
+  return token ? { Authorization: `Bearer ${token}` } : getNodeRedAuthHeader();
+}
+
+/**
+ * Resolve a bare Bearer token string (no "Authorization"/"Bearer " wrapping),
+ * for callers that need to authenticate over a channel other than an HTTP
+ * header — e.g. Node-RED's /comms WebSocket, which authenticates via an
+ * in-band `{ auth: "<token>" }` message, not connection headers. Returns
+ * undefined when there's no token to send (basic mode with the exchange not
+ * opted into, or no credentials at all) — those cases have nothing to
+ * authenticate the WebSocket with, whatever this server does have.
+ */
+export async function resolveNodeRedAuthToken(forceRefresh = false): Promise<string | undefined> {
+  return resolveBearerToken(forceRefresh);
 }
 
 /**


### PR DESCRIPTION
## Summary

`NODERED_USERNAME` + `NODERED_PASSWORD` currently sends a static HTTP Basic
auth header on every request to Node-RED's admin API. Node-RED's admin API
only ever accepts a **Bearer token** (issued via the `/auth/token` password
grant) — it does not support HTTP Basic auth at all. As a result, every
request made in this auth mode currently fails with `401`, regardless of
whether the credentials are correct.

`login()`/`refreshToken()` in `nodered-api.ts` already implement the correct
`/auth/token` exchange, but neither is ever called from anywhere in the
request path — they're dead code.

## Fix

- `resolveNodeRedAuthHeader()` (new, in `src/utils/auth.ts`) exchanges
  `NODERED_USERNAME`/`NODERED_PASSWORD` for a bearer token on demand, caches
  it in memory, and transparently re-exchanges it ~60s before it expires (or
  immediately after a `401`). `NODERED_API_TOKEN` and unauthenticated modes
  pass through unchanged.
- `NodeRedAPIClient`'s request/response interceptors now call this instead of
  sending the static Basic header.
- **Multi-tenant safety**: a client constructed with its own explicit
  `Authorization` header — the per-tenant OAuth path in `callToolPublic` —
  is left untouched. Without this guard, the new global token resolver would
  have overwritten a tenant-supplied header with the operator's own Node-RED
  credentials on every request, leaking them to a tenant-supplied URL.
- The token exchange now respects `NODERED_TIMEOUT` like the rest of the
  client, instead of being able to hang indefinitely if Node-RED accepts the
  connection but stalls on `/auth/token`.
- Same fix applied to the two WebSocket connection points
  (`nodered-ws-client.ts`, `node-error-checker.ts`) that also send this
  header.
- Docs: added `NODERED_API_TOKEN` to the README env var table and a short
  "Node-RED Authentication" section explaining the Bearer-only requirement
  and the two supported auth modes.

## Test plan

- [x] `yarn type-check` — clean
- [x] `yarn lint` — 0 errors
- [x] `yarn test` — 886/886 passing (see note below on one unrelated flake)
- [x] Added unit tests: token caching/reuse, forced refresh, concurrent
      request de-duplication, the 401-retry-once path, and the per-tenant
      override skipping the global resolver
- [x] Manually verified against a real Node-RED instance with `adminAuth`
      enabled: username/password now successfully exchanges for a token and
      completes a real `GET /flows` (previously 401'd on every call)

## Notes for the maintainer (pre-existing, unrelated to this PR)

- `yarn format:check` currently fails on `README.md` on `main` itself
  (verified on a clean checkout before this PR's changes) — this PR's new
  README content is hand-formatted to match the file's existing style rather
  than running Prettier over the whole file, to avoid an unrelated ~160-line
  reformat noise in the diff. Happy to run the full reformat in a separate
  PR if preferred.
- `node-error-checker.test.ts`'s "returns empty errors when no status
  messages arrive within timeout" test has a tight 100ms budget and flakes
  under CPU load; reproduced on unmodified `main` as well, so it's unrelated
  to this change.