### PR TITLE
Add read-only mode (MCP_READ_ONLY) to gate write tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to
 
 ### Added
 
+- **Read-Only Mode (`MCP_READ_ONLY`)**: Structurally prevents mutation of
+  Node-RED flows when exposing this server to remote agents
+  - Write tools (`create_flow`, `update_flow`, `delete_flow`, `enable_flow`,
+    `disable_flow`, `set_context`, `delete_context`, `install_module`) are
+    removed from `getToolDefinitions()`/tool listings entirely, so clients never
+    see them as available capabilities
+  - `callTool` also rejects these tools if called directly by name, as
+    defense-in-depth against a client that caches an older tool list
+  - Derived from each tool's existing `readOnlyHint` annotation rather than a
+    separately maintained tool-name list
+  - Pairs with `delete_flow`'s existing `dryRun` default; all read, search,
+    diagnostic, resource, and prompt capabilities remain available
 - **MCP SDK 1.22.0 Upgrade**: Updated from 1.17.5 to latest SDK version with
   protocol improvements
 - **Circuit Breaker Pattern**: Implemented comprehensive circuit breaker for

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The server asks clarifying questions mid-call when required parameters are missi
 
 - [Quick Start](#-quick-start)
 - [Available Tools](#-available-mcp-tools)
+- [Read-Only Mode](#-read-only-mode)
 - [Resources](#-mcp-resources)
 - [Prompts](#-mcp-prompts)
 - [Connecting](#-connecting-to-the-server)
@@ -110,6 +111,22 @@ docker run -e NODERED_URL=http://your-nodered:1880 \
 | `get_flow_state` | Get flow runtime state (started/stopped) | — |
 | `get_settings` | Get Node-RED runtime settings | — |
 | `get_runtime_info` | Get Node-RED version and system info | — |
+
+## 🔒 Read-Only Mode
+
+Set `MCP_READ_ONLY=true` to structurally prevent any mutation of your Node-RED
+flows — useful when exposing this server to remote AI agents where an accidental
+or unintended write to a live/production instance is a real risk.
+
+When enabled, write tools (`create_flow`, `update_flow`, `delete_flow`,
+`enable_flow`, `disable_flow`, `set_context`, `delete_context`,
+`install_module`) are removed from the tool list entirely — clients never
+see them as available capabilities — and are also rejected if called
+directly by name. All read, search, diagnostic, resource, and prompt
+capabilities remain fully available. This pairs naturally with `delete_flow`'s
+existing `dryRun` default for deployments that need read/write in the same
+session but still want an extra layer of protection against accidental
+writes.
 
 ## 📦 MCP Resources
 
@@ -186,6 +203,7 @@ claude mcp add node-red \
 | `MCP_TRANSPORT` | No | `http` | `http` or `stdio` |
 | `MCP_USERNAME` | No | — | MCP server auth username |
 | `MCP_PASSWORD` | No | — | MCP server auth password |
+| `MCP_READ_ONLY` | No | `false` | Set `true` to hide write tools and reject write calls — see [Read-Only Mode](#-read-only-mode) |
 | `HOST` | No | `0.0.0.0` | Bind address |
 | `PORT` | No | `3000` | Listen port |
 | `LOG_LEVEL` | No | `info` | `debug`, `info`, `warn`, `error` |

--- a/src/server/mcp-server.test.ts
+++ b/src/server/mcp-server.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import {
   mockFlows,
@@ -359,6 +359,49 @@ describe('McpNodeRedServer', () => {
       expect(tool?.annotations?.readOnlyHint).toBe(true);
       expect(tool?.inputSchema.properties).toHaveProperty('includeWarnings');
       expect(tool?.inputSchema.properties).toHaveProperty('timeoutMs');
+    });
+  });
+
+  describe('Read-only mode (MCP_READ_ONLY)', () => {
+    afterEach(() => {
+      delete process.env.MCP_READ_ONLY;
+    });
+
+    it('does not filter tools when MCP_READ_ONLY is unset', () => {
+      const tools = mcpServer.getToolDefinitions();
+      expect(tools.find(t => t.name === 'create_flow')).toBeDefined();
+      expect(tools.length).toBe(20);
+    });
+
+    it('hides write tools from the tool list when MCP_READ_ONLY=true', () => {
+      process.env.MCP_READ_ONLY = 'true';
+
+      const tools = mcpServer.getToolDefinitions();
+
+      expect(tools.every(t => t.annotations?.readOnlyHint)).toBe(true);
+      expect(tools.find(t => t.name === 'create_flow')).toBeUndefined();
+      expect(tools.find(t => t.name === 'get_flows')).toBeDefined();
+    });
+
+    it('rejects a write tool call when MCP_READ_ONLY=true', async () => {
+      process.env.MCP_READ_ONLY = 'true';
+
+      const result = await mcpServer.callTool('create_flow', { flowData: {} });
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).toContain('read-only mode');
+      expect(mockNodeRedClient.createFlow).not.toHaveBeenCalled();
+    });
+
+    it('still allows a read tool call when MCP_READ_ONLY=true', async () => {
+      process.env.MCP_READ_ONLY = 'true';
+
+      const result = await mcpServer.callTool('get_flows', {});
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.success).toBe(true);
+      expect(mockNodeRedClient.getFlowSummaries).toHaveBeenCalled();
     });
   });
 

--- a/src/server/mcp-server.test.ts
+++ b/src/server/mcp-server.test.ts
@@ -363,14 +363,24 @@ describe('McpNodeRedServer', () => {
   });
 
   describe('Read-only mode (MCP_READ_ONLY)', () => {
+    let originalReadOnly: string | undefined;
+
+    beforeEach(() => {
+      originalReadOnly = process.env.MCP_READ_ONLY;
+    });
+
     afterEach(() => {
-      delete process.env.MCP_READ_ONLY;
+      if (originalReadOnly === undefined) {
+        delete process.env.MCP_READ_ONLY;
+      } else {
+        process.env.MCP_READ_ONLY = originalReadOnly;
+      }
     });
 
     it('does not filter tools when MCP_READ_ONLY is unset', () => {
       const tools = mcpServer.getToolDefinitions();
       expect(tools.find(t => t.name === 'create_flow')).toBeDefined();
-      expect(tools.length).toBe(20);
+      expect(tools.some(t => !t.annotations?.readOnlyHint)).toBe(true);
     });
 
     it('hides write tools from the tool list when MCP_READ_ONLY=true', () => {

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -309,9 +309,29 @@ export class McpNodeRedServer {
   }
 
   /**
-   * Get tool definitions
+   * True when MCP_READ_ONLY=true — write tools are hidden from tool listings
+   * and rejected if called directly, leaving all read/search/diagnostic
+   * capabilities intact. Useful when exposing this server to remote agents
+   * where accidental mutation of a live Node-RED instance is a real risk.
+   */
+  private isReadOnlyMode(): boolean {
+    return process.env.MCP_READ_ONLY === 'true';
+  }
+
+  /**
+   * Get tool definitions, filtered to read-only tools when MCP_READ_ONLY is set
    */
   public getToolDefinitions() {
+    const tools = this.getAllToolDefinitions();
+    return this.isReadOnlyMode() ? tools.filter(tool => tool.annotations?.readOnlyHint) : tools;
+  }
+
+  /**
+   * Full, unfiltered tool definitions (used internally so callTool can give a
+   * clear error when a write tool is called while read-only mode is active,
+   * rather than an ambiguous "unknown tool" error)
+   */
+  private getAllToolDefinitions() {
     return [
       // Core Flow Management Tools (Optimized)
       {
@@ -786,6 +806,15 @@ export class McpNodeRedServer {
     let result: McpToolResult;
 
     try {
+      if (this.isReadOnlyMode()) {
+        const tool = this.getAllToolDefinitions().find(t => t.name === name);
+        if (tool && !tool.annotations?.readOnlyHint) {
+          throw new Error(
+            `Tool '${name}' is unavailable: the server is running in read-only mode (MCP_READ_ONLY=true)`
+          );
+        }
+      }
+
       switch (name) {
         // Core Flow Management Tools
         case 'get_flows': {


### PR DESCRIPTION
Closes #102

## Summary

When exposing this server to remote AI agents, the only existing write
safeguard is `delete_flow`'s `dryRun` default — `create_flow`, `update_flow`,
`enable_flow`, `disable_flow`, `set_context`, `delete_context`, and
`install_module` have no equivalent guard. This adds an opt-in read-only mode
that structurally removes those tools rather than just rejecting calls at
runtime, per the issue's request.

## Implementation

- `MCP_READ_ONLY=true` filters `getToolDefinitions()` down to tools whose
  `annotations.readOnlyHint` is `true` — this is derived from the annotation
  every tool already declares, not a separately maintained tool-name list, so
  it can't drift out of sync as tools are added/changed.
- Since `getToolDefinitions()` backs both the real MCP protocol tool listing
  (`ListToolsRequestSchema`) and the HTTP `listTools()`/discovery paths, this
  one change covers every client-facing listing surface.
- `callTool` also checks read-only mode directly (against the full,
  unfiltered tool set) and rejects a write tool by name with a clear error —
  defense-in-depth against a client that cached an older tool list rather than
  just hiding the capability from the UI.
- All read, search, diagnostic, resource, and prompt tools are unaffected.

## Test plan

- [x] `yarn type-check` — clean
- [x] `yarn lint` — 0 errors
- [x] `yarn test` — 880/881 passing (the 1 failure is the same pre-existing
      unrelated flaky timeout test noted in #103, reproduces on unmodified
      `main`)
- [x] Added 4 tests: tool list is unfiltered by default, tool list is
      filtered to read-only tools when enabled, a write tool call is rejected
      with a clear error, a read tool call still succeeds
- [x] Manually verified against a real Node-RED instance: tool count goes
      from 20 → 12 with `MCP_READ_ONLY=true`, `create_flow` is both absent
      from the list and rejected if called directly, `get_flows` is
      unaffected

## Docs

Added a "Read-Only Mode" section to the README and the `MCP_READ_ONLY`
env var to the reference table, plus a CHANGELOG entry.