### PR TITLE
fix: production image target, unified auth flag, diagnosable tool errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,7 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile
+          target: production
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,7 +67,39 @@ RUN node .yarn/releases/yarn-stable-temp.cjs workspaces focus --production && \
     node .yarn/releases/yarn-stable-temp.cjs cache clean
 
 # ============================================================================
-# Stage 4: Production image
+# Stage 4: Development image
+#
+# Declared before `production` on purpose: an untargeted `docker build` uses
+# the *last* stage in the file, so `production` must stay at the bottom to
+# keep it the default. Build this one explicitly with `--target development`.
+# ============================================================================
+FROM dependencies AS development
+
+# Install development tools (must run as root)
+USER root
+RUN apk add --no-cache \
+        git \
+        openssh-client && \
+    rm -rf /var/cache/apk/*
+USER mcpserver
+
+# Copy source code
+COPY --chown=mcpserver:mcpserver . .
+
+# Set development environment
+ENV NODE_ENV=development
+ENV LOG_LEVEL=debug
+ENV MCP_TRANSPORT=both
+ENV HTTP_ENABLED=true
+
+# Expose additional ports for development
+EXPOSE 3000 9229
+
+# Development command with hot reload
+CMD ["node", ".yarn/releases/yarn-stable-temp.cjs", "dev"]
+
+# ============================================================================
+# Stage 5: Production image (default target)
 # ============================================================================
 FROM base AS production
 
@@ -137,31 +169,3 @@ LABEL maintainer="your-email@example.com"
 LABEL security.contact="security@example.com"
 LABEL org.opencontainers.image.created="2024-12-17"
 LABEL org.opencontainers.image.revision="main"
-
-# ============================================================================
-# Alternative: Development image
-# ============================================================================
-FROM dependencies AS development
-
-# Install development tools (must run as root)
-USER root
-RUN apk add --no-cache \
-        git \
-        openssh-client && \
-    rm -rf /var/cache/apk/*
-USER mcpserver
-
-# Copy source code
-COPY --chown=mcpserver:mcpserver . .
-
-# Set development environment
-ENV NODE_ENV=development
-ENV LOG_LEVEL=debug
-ENV MCP_TRANSPORT=both
-ENV HTTP_ENABLED=true
-
-# Expose additional ports for development
-EXPOSE 3000 9229
-
-# Development command with hot reload
-CMD ["node", ".yarn/releases/yarn-stable-temp.cjs", "dev"] 

--- a/env.example
+++ b/env.example
@@ -19,6 +19,9 @@ JWT_EXPIRES_IN=24h
 API_KEY=your-api-key-for-external-access
 
 # Claude Integration Settings
+# Auth is required unless this is set explicitly to `false`. The value is used
+# both for enforcement and for what /.well-known/mcp-server reports, so the two
+# can never disagree.
 CLAUDE_AUTH_REQUIRED=false
 CLAUDE_COMPATIBLE_MODE=true
 DEBUG_CLAUDE_CONNECTIONS=true

--- a/src/server/express-app.test.ts
+++ b/src/server/express-app.test.ts
@@ -105,7 +105,7 @@ vi.mock('../utils/auth.js', () => ({
 }));
 
 // Import after mocks
-import { ExpressApp } from './express-app.js';
+import { ExpressApp, isClaudeAuthRequired } from './express-app.js';
 import type { McpNodeRedServer } from './mcp-server.js';
 
 describe('ExpressApp', () => {
@@ -667,5 +667,40 @@ describe('ExpressApp Configuration', () => {
     const app = expressApp.getApp();
 
     expect(app).toBeDefined();
+  });
+});
+
+describe('isClaudeAuthRequired', () => {
+  const original = process.env.CLAUDE_AUTH_REQUIRED;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.CLAUDE_AUTH_REQUIRED;
+    } else {
+      process.env.CLAUDE_AUTH_REQUIRED = original;
+    }
+  });
+
+  it('should require auth when unset', () => {
+    delete process.env.CLAUDE_AUTH_REQUIRED;
+
+    expect(isClaudeAuthRequired()).toBe(true);
+  });
+
+  it('should require auth when set to true', () => {
+    process.env.CLAUDE_AUTH_REQUIRED = 'true';
+
+    expect(isClaudeAuthRequired()).toBe(true);
+  });
+
+  it('should only opt out on an explicit false', () => {
+    process.env.CLAUDE_AUTH_REQUIRED = 'false';
+    expect(isClaudeAuthRequired()).toBe(false);
+
+    process.env.CLAUDE_AUTH_REQUIRED = ' FALSE ';
+    expect(isClaudeAuthRequired()).toBe(false);
+
+    process.env.CLAUDE_AUTH_REQUIRED = 'no';
+    expect(isClaudeAuthRequired()).toBe(true);
   });
 });

--- a/src/server/express-app.ts
+++ b/src/server/express-app.ts
@@ -29,6 +29,22 @@ import { OAuthServer } from './oauth-server.js';
 import { SessionManager } from './session-manager.js';
 import { SSEHandler } from './sse-handler.js';
 
+/**
+ * Single source of truth for `CLAUDE_AUTH_REQUIRED`.
+ *
+ * This used to be read inline with two different fallbacks (`=== 'true'` in the
+ * enforcement path, `!== 'false'` in the discovery/debug reporting paths), so an
+ * unset variable made the server report one thing and do another. Auth is
+ * required unless the variable is explicitly set to `false`, which matches the
+ * unconditional `requireAuth` gate on the MCP/SSE endpoints.
+ *
+ * Read lazily (not captured at module load) so tests and runtime code that
+ * mutate `process.env` still see the current value.
+ */
+export function isClaudeAuthRequired(): boolean {
+  return process.env.CLAUDE_AUTH_REQUIRED?.trim().toLowerCase() !== 'false';
+}
+
 export interface ExpressAppConfig {
   port: number;
   host: string;
@@ -304,9 +320,10 @@ export class ExpressApp {
         const sessionId = req.headers['mcp-session-id'] as string | undefined;
         const authReq = req as AuthRequest;
 
-        // Enforce auth when CLAUDE_AUTH_REQUIRED=true
-        const authRequired = process.env.CLAUDE_AUTH_REQUIRED === 'true';
-        if (authRequired) {
+        // Enforce the OAuth token requirement, but only for requests that
+        // `requireAuth` let through on a non-Bearer scheme's behalf — API key and
+        // Basic clients are already authenticated and must not be rejected here.
+        if (isClaudeAuthRequired() && !authReq.auth?.isAuthenticated) {
           const auth = req.headers.authorization;
           if (!auth?.startsWith('Bearer ')) {
             const resourceUrl =
@@ -1207,7 +1224,7 @@ export class ExpressApp {
       '/.well-known/mcp-server',
       asyncHandler(async (req: Request, res: Response) => {
         const isClaudeMode = process.env.CLAUDE_COMPATIBLE_MODE === 'true';
-        const authRequired = process.env.CLAUDE_AUTH_REQUIRED !== 'false';
+        const authRequired = isClaudeAuthRequired();
 
         const serverInfo = {
           name: 'nodered-mcp-server',
@@ -1278,7 +1295,7 @@ export class ExpressApp {
         const debugInfo = {
           server: {
             claudeMode: process.env.CLAUDE_COMPATIBLE_MODE === 'true',
-            authRequired: process.env.CLAUDE_AUTH_REQUIRED !== 'false',
+            authRequired: isClaudeAuthRequired(),
             acceptAnyToken: process.env.ACCEPT_ANY_BEARER_TOKEN === 'true',
             fallbackEnabled: process.env.AUTH_FALLBACK_ENABLED === 'true',
             debugConnections: process.env.DEBUG_CLAUDE_CONNECTIONS === 'true',

--- a/src/server/mcp-server.test.ts
+++ b/src/server/mcp-server.test.ts
@@ -25,6 +25,7 @@ import {
   mockSettings,
 } from '../../test/fixtures/responses.js';
 import { NodeRedAPIClient } from '../services/nodered-api.js';
+import { NodeRedError } from '../utils/error-handling.js';
 
 import { McpNodeRedServer } from './mcp-server.js';
 import { SSEHandler } from './sse-handler.js';
@@ -1024,6 +1025,36 @@ describe('McpNodeRedServer', () => {
 
       expect(parsed.success).toBe(false);
       expect(parsed.error).toContain('Unauthorized');
+    });
+
+    it('should surface the upstream status of a Node-RED failure', async () => {
+      mockNodeRedClient.getSettings.mockRejectedValueOnce(
+        new NodeRedError('Node-RED API error in getSettings: HTTP 403 Forbidden', 403, 403, {
+          error: 'permission denied',
+        })
+      );
+      const result = await mcpServer.callTool('get_settings', {});
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.errorDetails).toMatchObject({
+        code: 'NODERED_ERROR',
+        statusCode: 403,
+        upstreamStatus: 403,
+        upstreamResponse: { error: 'permission denied' },
+      });
+    });
+
+    it('should describe a thrown non-Error value instead of "Unknown error"', async () => {
+      mockNodeRedClient.getSettings.mockRejectedValueOnce({ status: 500 });
+      const result = await mcpServer.callTool('get_settings', {});
+      const parsed = JSON.parse(result.content[0].text);
+
+      expect(parsed.success).toBe(false);
+      expect(parsed.error).not.toBe('Unknown error');
+      expect(parsed.error).toContain('get_settings');
+      expect(parsed.error).toContain('500');
+      expect(parsed.errorDetails.code).toBe('INTERNAL_ERROR');
     });
   });
 

--- a/src/server/mcp-server.ts
+++ b/src/server/mcp-server.ts
@@ -29,7 +29,14 @@ import {
   NodeRedPromptTemplate,
 } from '../types/mcp-extensions.js';
 import type { NodeRedCredentials } from '../types/oauth.js';
-import { validateRequired, validateTypes } from '../utils/error-handling.js';
+import {
+  AppError,
+  NodeRedError,
+  logDebug,
+  safeStringify,
+  validateRequired,
+  validateTypes,
+} from '../utils/error-handling.js';
 
 import {
   applyPagination,
@@ -43,6 +50,68 @@ import { SSEHandler } from './sse-handler.js';
 
 const SEARCH_RESULTS_LIMIT = 10;
 const SEARCH_SKIP_PROPS = new Set(['id', 'z', 'x', 'y', 'wires']);
+const UPSTREAM_RESPONSE_LIMIT = 2000;
+
+/**
+ * Truncate an upstream response body so a large flow dump or HTML login page
+ * doesn't get echoed back to the client in full.
+ */
+function truncateUpstreamResponse(response: unknown): unknown {
+  if (response === undefined || response === null) return undefined;
+
+  const serialized = typeof response === 'string' ? response : JSON.stringify(response);
+  if (serialized === undefined) return undefined;
+  if (serialized.length <= UPSTREAM_RESPONSE_LIMIT) return response;
+
+  return `${serialized.slice(0, UPSTREAM_RESPONSE_LIMIT)}… (truncated, ${serialized.length} bytes)`;
+}
+
+/**
+ * Turn a thrown value into an error message plus structured detail.
+ *
+ * Tool failures used to collapse to `error.message` — or the literal string
+ * "Unknown error" for anything that wasn't an `Error` — which left callers with
+ * no way to tell a 403 from a 404 or a network failure.
+ */
+function describeToolFailure(
+  toolName: string,
+  error: unknown
+): Pick<McpToolResult, 'error' | 'errorDetails'> {
+  if (error instanceof NodeRedError) {
+    return {
+      error: error.message,
+      errorDetails: {
+        code: error.code,
+        statusCode: error.statusCode,
+        ...(error.nodeRedStatusCode !== undefined
+          ? { upstreamStatus: error.nodeRedStatusCode }
+          : {}),
+        ...(error.nodeRedResponse !== undefined
+          ? { upstreamResponse: truncateUpstreamResponse(error.nodeRedResponse) }
+          : {}),
+      },
+    };
+  }
+
+  if (error instanceof AppError) {
+    return {
+      error: error.message,
+      errorDetails: { code: error.code, statusCode: error.statusCode },
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      error: error.message || `${error.name} thrown with no message`,
+      errorDetails: { code: error.name || 'INTERNAL_ERROR' },
+    };
+  }
+
+  return {
+    error: `Tool '${toolName}' threw a non-Error value: ${safeStringify(error)}`,
+    errorDetails: { code: 'INTERNAL_ERROR' },
+  };
+}
 
 const NODERED_RESOURCE_META: Record<string, { name: string; description: string }> = {
   flows: { name: 'Node-RED Flows', description: 'All flow tabs in the Node-RED instance' },
@@ -1154,9 +1223,17 @@ export class McpNodeRedServer {
     } catch (error) {
       result = {
         success: false,
-        error: error instanceof Error ? error.message : 'Unknown error',
+        ...describeToolFailure(name, error),
         timestamp,
       };
+
+      logDebug(`Tool '${name}' failed`, {
+        tool: name,
+        args,
+        error: result.error,
+        details: result.errorDetails,
+        stack: error instanceof Error ? error.stack : undefined,
+      });
     }
 
     return {

--- a/src/types/mcp-extensions.ts
+++ b/src/types/mcp-extensions.ts
@@ -20,6 +20,18 @@ export interface McpToolResult {
   success: boolean;
   data?: any;
   error?: string;
+  /**
+   * Machine-readable detail for a failed call: the error code, the HTTP status
+   * the server would map it to, and — for Node-RED failures — the upstream
+   * status and response body. `error` alone could not distinguish a permission
+   * error from a missing endpoint.
+   */
+  errorDetails?: {
+    code: string;
+    statusCode?: number;
+    upstreamStatus?: number;
+    upstreamResponse?: unknown;
+  };
   timestamp: string;
 }
 

--- a/src/utils/error-handling.test.ts
+++ b/src/utils/error-handling.test.ts
@@ -27,6 +27,8 @@ import {
   sanitizeError,
   isOperationalError,
   safeStringify,
+  isDebugLoggingEnabled,
+  logDebug,
 } from './error-handling.js';
 
 describe('Error Classes', () => {
@@ -471,6 +473,116 @@ describe('handleNodeRedError', () => {
       expect(e).toBeInstanceOf(NodeRedError);
       expect((e as NodeRedError).statusCode).toBe(502);
     }
+  });
+
+  it('should report the upstream status instead of "Unknown error" for a bodyless response', () => {
+    const error = {
+      response: {
+        status: 403,
+        statusText: 'Forbidden',
+        data: undefined,
+        headers: {},
+      },
+      config: { method: 'get', url: '/flows' },
+    };
+
+    try {
+      handleNodeRedError(error, 'getFlows');
+      expect.unreachable('handleNodeRedError should throw');
+    } catch (e) {
+      const err = e as NodeRedError;
+      expect(err.message).toContain('HTTP 403 Forbidden');
+      expect(err.message).toContain('GET /flows');
+      expect(err.message).not.toContain('Unknown error');
+      expect(err.nodeRedStatusCode).toBe(403);
+    }
+  });
+
+  it('should keep an unrecognised response body shape in the message', () => {
+    const error = {
+      response: {
+        status: 400,
+        data: { reason: 'invalid_flow', node: 'n1' },
+        headers: {},
+      },
+    };
+
+    try {
+      handleNodeRedError(error, 'updateFlow');
+      expect.unreachable('handleNodeRedError should throw');
+    } catch (e) {
+      expect((e as NodeRedError).message).toContain('invalid_flow');
+    }
+  });
+
+  it('should tolerate a response without headers', () => {
+    const error = { response: { status: 502, data: 'bad gateway' } };
+
+    expect(() => handleNodeRedError(error, 'getFlows')).toThrow(NodeRedError);
+    expect(() => handleNodeRedError(error, 'getFlows')).toThrow(/bad gateway/);
+  });
+
+  it('should include the network error code and request', () => {
+    const error = {
+      request: {},
+      code: 'ECONNREFUSED',
+      message: 'connect ECONNREFUSED 127.0.0.1:1880',
+      config: { method: 'post', url: '/flows' },
+    };
+
+    try {
+      handleNodeRedError(error, 'deployFlows');
+      expect.unreachable('handleNodeRedError should throw');
+    } catch (e) {
+      const err = e as NodeRedError;
+      expect(err.message).toContain('ECONNREFUSED');
+      expect(err.message).toContain('POST /flows');
+      expect(err.statusCode).toBe(503);
+    }
+  });
+});
+
+describe('logDebug', () => {
+  const originalLogLevel = process.env.LOG_LEVEL;
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    writeSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    writeSpy.mockRestore();
+    if (originalLogLevel === undefined) {
+      delete process.env.LOG_LEVEL;
+    } else {
+      process.env.LOG_LEVEL = originalLogLevel;
+    }
+  });
+
+  it('should write to stderr when LOG_LEVEL=debug', () => {
+    process.env.LOG_LEVEL = 'debug';
+
+    expect(isDebugLoggingEnabled()).toBe(true);
+
+    logDebug('tool failed', { tool: 'get_flows' });
+
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    const line = writeSpy.mock.calls[0]![0] as string;
+    expect(JSON.parse(line)).toMatchObject({
+      level: 'debug',
+      message: 'tool failed',
+      context: { tool: 'get_flows' },
+    });
+  });
+
+  it('should stay silent at other log levels', () => {
+    process.env.LOG_LEVEL = 'info';
+
+    expect(isDebugLoggingEnabled()).toBe(false);
+
+    logDebug('tool failed');
+
+    expect(writeSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/utils/error-handling.ts
+++ b/src/utils/error-handling.ts
@@ -197,39 +197,93 @@ export function asyncHandler<T extends any[]>(
   };
 }
 
+const RESPONSE_PREVIEW_LIMIT = 500;
+
+/**
+ * Describe the request an Axios error came from, e.g. `GET /flows`.
+ * Returns undefined when the error carries no request config.
+ */
+function describeRequest(error: any): string | undefined {
+  const config = error?.config;
+  if (!config?.url) return undefined;
+  const method = String(config.method || 'get').toUpperCase();
+  return `${method} ${config.url}`;
+}
+
+/**
+ * Summarise an upstream response body for an error message. Node-RED is not
+ * consistent about the shape here: some endpoints return `{message}`, some
+ * `{error}`, some a bare string, some nothing at all. Falling straight through
+ * to "Unknown error" hid all of it, so keep whatever is actually there.
+ */
+function summarizeResponseBody(data: unknown): string | undefined {
+  if (data === undefined || data === null || data === '') return undefined;
+
+  if (typeof data === 'string') {
+    const trimmed = data.trim();
+    return trimmed ? trimmed.slice(0, RESPONSE_PREVIEW_LIMIT) : undefined;
+  }
+
+  if (typeof data === 'object') {
+    const body = data as Record<string, any>;
+    const known = body.message || body.error_description || body.error;
+    if (typeof known === 'string' && known.trim()) return known.trim();
+    return safeStringify(body).slice(0, RESPONSE_PREVIEW_LIMIT);
+  }
+
+  if (typeof data === 'number' || typeof data === 'boolean' || typeof data === 'bigint') {
+    return String(data);
+  }
+
+  return undefined;
+}
+
 /**
  * Handle Node-RED API errors
  */
 export function handleNodeRedError(error: any, context: string): never {
+  const request = describeRequest(error);
+  const requestSuffix = request ? ` [${request}]` : '';
+
   if (error.response) {
     // Axios error with response
-    const { status, data } = error.response;
+    const { status, statusText, data } = error.response;
 
     // Check if this is a JSON parse error due to HTML response
-    const contentType = error.response.headers['content-type'] || '';
+    const contentType = error.response.headers?.['content-type'] || '';
     if (error.message?.includes('Unexpected token') && contentType.includes('text/html')) {
       throw new NodeRedError(
-        `Node-RED returned HTML instead of JSON in ${context}. This usually indicates an authentication redirect or configuration issue. Check your Node-RED admin settings and authentication.`,
+        `Node-RED returned HTML instead of JSON in ${context}${requestSuffix} (HTTP ${status}). This usually indicates an authentication redirect or configuration issue. Check your Node-RED admin settings and authentication.`,
         502,
         status,
         {
           originalError: error.message,
           contentType,
-          responsePreview: typeof data === 'string' ? data.substring(0, 200) : data,
+          request,
+          responsePreview:
+            typeof data === 'string' ? data.substring(0, RESPONSE_PREVIEW_LIMIT) : data,
         }
       );
     }
 
+    // Always surface the upstream status — a bare "Unknown error" makes a 403
+    // (missing permission) indistinguishable from a 404 (endpoint gone).
+    const detail = summarizeResponseBody(data);
+    const statusLabel = statusText ? `HTTP ${status} ${statusText}` : `HTTP ${status}`;
+
     throw new NodeRedError(
-      `Node-RED API error in ${context}: ${data?.message || data?.error || 'Unknown error'}`,
+      `Node-RED API error in ${context}${requestSuffix}: ${statusLabel}${
+        detail ? ` — ${detail}` : ' (no response body)'
+      }`,
       status >= 500 ? 502 : status, // Bad Gateway for server errors
       status,
       data
     );
   } else if (error.request) {
     // Network error
+    const code = error.code ? ` (${error.code})` : '';
     throw new NodeRedError(
-      `Failed to connect to Node-RED in ${context}: ${error.message}`,
+      `Failed to connect to Node-RED in ${context}${requestSuffix}: ${error.message}${code}`,
       503 // Service Unavailable
     );
   } else if (error.message?.includes('Node-RED returned HTML')) {
@@ -240,7 +294,7 @@ export function handleNodeRedError(error: any, context: string): never {
     );
   } else {
     // Other error
-    throw new NodeRedError(`Error in ${context}: ${error.message}`, 500);
+    throw new NodeRedError(`Error in ${context}${requestSuffix}: ${error.message}`, 500);
   }
 }
 
@@ -271,6 +325,32 @@ export function validateTypes(data: Record<string, any>, fieldTypes: Record<stri
       }
     }
   }
+}
+
+/**
+ * Whether `LOG_LEVEL=debug` was requested.
+ */
+export function isDebugLoggingEnabled(): boolean {
+  return process.env.LOG_LEVEL?.trim().toLowerCase() === 'debug';
+}
+
+/**
+ * Emit a debug line when `LOG_LEVEL=debug`.
+ *
+ * Writes to stderr, never stdout: stdout carries the JSON-RPC stream under the
+ * stdio transport and any stray write there corrupts it.
+ */
+export function logDebug(message: string, context?: Record<string, any>): void {
+  if (!isDebugLoggingEnabled()) return;
+
+  process.stderr.write(
+    `${safeStringify({
+      level: 'debug',
+      timestamp: new Date().toISOString(),
+      message,
+      ...(context ? { context } : {}),
+    })}\n`
+  );
 }
 
 /**


### PR DESCRIPTION
Addresses the three cleanup items in ziv-daniel/node-red-mcp#107.

1. Published image ran with NODE_ENV=development

   The CI docker job builds ./docker/Dockerfile without a --target, so BuildKit used the last stage in the file — which was `development`. That is what shipped as :latest, with NODE_ENV=development, LOG_LEVEL=debug and the tsx hot-reload CMD.

   Pin `target: production` in the workflow, and move the `development` stage above `production` so an untargeted local build also lands on the production stage. docker-compose.yml already passes `target: development` explicitly and is unaffected.

2. CLAUDE_AUTH_REQUIRED was read with two different defaults

   The enforcement path treated unset as "auth not required" while the /.well-known/mcp-server and /debug/claude-connection reporting paths treated unset as "auth required", so the server could advertise one posture and apply another.

   Replace all three reads with isClaudeAuthRequired(), which requires auth unless the variable is explicitly `false` — matching the unconditional requireAuth gate already on those endpoints. The check is a function rather than a module-level const so it still observes process.env mutated after import.

   The POST /mcp block additionally now skips its Bearer-only re-check for requests requireAuth already authenticated, so API-key and Basic clients are not rejected by the stricter default.

3. Tool failures collapsed to "Unknown error"

   handleNodeRedError fell through to the literal string "Unknown error" whenever the Node-RED response body lacked `message`/`error`, and dropped the status entirely — a 403 was indistinguishable from a 404. It now reports the upstream status and statusText, the method and URL, the network error code for connection failures, and preserves unrecognised response bodies instead of discarding them. It also tolerates a response with no headers.

   callTool no longer flattens the error to error.message: it keeps the message and adds errorDetails { code, statusCode, upstreamStatus, upstreamResponse } (body truncated at 2 KB), and describes thrown non-Error values rather than labelling them "Unknown error".

   LOG_LEVEL was validated by the config schema but never consumed on this path, so `LOG_LEVEL=debug` produced no output. Failed tool calls now emit a debug line via logDebug, written to stderr so it cannot corrupt the stdio JSON-RPC stream.


Claude-Session: https://claude.ai/code/session_01318azTDgNDQa7j6Q5Wy7o2