### PR TITLE
fix: IPv6-aware rate-limit keys and configurable trust proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,17 +203,43 @@ claude mcp add node-red \
 
 ## ⚙️ Environment Variables
 
-| Variable                      | Required | Default                   | Description                                                                                    |
-| ----------------------------- | -------- | ------------------------- | ---------------------------------------------------------------------------------------------- |
-| `NODERED_URL`                 | Yes      | —                         | URL of your Node-RED instance                                                                  |
-| `NODERED_USERNAME`            | No       | —                         | Node-RED admin username                                                                        |
-| `NODERED_PASSWORD`            | No       | —                         | Node-RED admin password                                                                        |
-| `MCP_TRANSPORT`               | No       | `http`                    | `http` or `stdio`                                                                              |
-| `MCP_USERNAME`                | No       | —                         | MCP server auth username                                                                       |
-| `MCP_PASSWORD`                | No       | —                         | MCP server auth password                                                                       |
-| `MCP_READ_ONLY`               | No       | `false`                   | Set `true` to hide write tools and reject write calls — see [Read-Only Mode](#-read-only-mode) |
-| `HOST`                        | No       | `0.0.0.0`                 | Bind address                                                                                   |
-| `PORT`                        | No       | `3000`                    | Listen port                                                                                    |
-| `LOG_LEVEL`                   | No       | `info`                    | `debug`, `info`, `warn`, `error`                                                               |
-| `NODERED_REJECT_UNAUTHORIZED` | No       | `true`                    | Set `false` to allow self-signed TLS                                                           |
-| `EMBEDDING_MODEL`             | No       | `Xenova/all-MiniLM-L6-v2` | Model for semantic search                                                                      |
+| Variable                      | Required | Default                   | Description                                                                                         |
+| ----------------------------- | -------- | ------------------------- | --------------------------------------------------------------------------------------------------- |
+| `NODERED_URL`                 | Yes      | —                         | URL of your Node-RED instance                                                                       |
+| `NODERED_USERNAME`            | No       | —                         | Node-RED admin username                                                                             |
+| `NODERED_PASSWORD`            | No       | —                         | Node-RED admin password                                                                             |
+| `MCP_TRANSPORT`               | No       | `http`                    | `http` or `stdio`                                                                                   |
+| `MCP_USERNAME`                | No       | —                         | MCP server auth username                                                                            |
+| `MCP_PASSWORD`                | No       | —                         | MCP server auth password                                                                            |
+| `MCP_READ_ONLY`               | No       | `false`                   | Set `true` to hide write tools and reject write calls — see [Read-Only Mode](#-read-only-mode)      |
+| `HOST`                        | No       | `0.0.0.0`                 | Bind address                                                                                        |
+| `PORT`                        | No       | `3000`                    | Listen port                                                                                         |
+| `LOG_LEVEL`                   | No       | `info`                    | `debug`, `info`, `warn`, `error`                                                                    |
+| `NODERED_REJECT_UNAUTHORIZED` | No       | `true`                    | Set `false` to allow self-signed TLS                                                                |
+| `TRUST_PROXY`                 | No       | `false`                   | Reverse proxy hops to trust — see [Running Behind a Reverse Proxy](#running-behind-a-reverse-proxy) |
+| `EMBEDDING_MODEL`             | No       | `Xenova/all-MiniLM-L6-v2` | Model for semantic search                                                                           |
+
+### Running Behind a Reverse Proxy
+
+Express ignores `X-Forwarded-For` unless you tell it which proxies to trust.
+Left unset behind a proxy, every client resolves to the proxy's own address and
+shares a single rate-limit bucket. `TRUST_PROXY` sets Express's `trust proxy`:
+
+| Value                       | Meaning                                                                 |
+| --------------------------- | ----------------------------------------------------------------------- |
+| unset, empty, or `false`    | Don't trust `X-Forwarded-For`; use the socket address (default)         |
+| `1`, `2`, …                 | **Recommended.** Number of proxy hops in front of this server           |
+| `loopback`                  | Trust `127.0.0.1/8`, `::1/128` — also `linklocal` and `uniquelocal`     |
+| `10.0.0.0/8`, `192.168.1.5` | Trust specific addresses or CIDR ranges                                 |
+| `loopback,10.0.0.0/8`       | Comma-separated — any combination of the above                          |
+| `true`                      | Trust every hop. Works, but **not recommended** — see the warning below |
+
+Use the hop count wherever you can: `TRUST_PROXY=1` for a single Traefik, nginx
+or Caddy in front, `TRUST_PROXY=2` for something like Traefik in front of
+Pomerium. Count the proxies that actually append to `X-Forwarded-For`.
+
+`TRUST_PROXY=true` is accepted, but the server logs a warning on startup and
+express-rate-limit reports it as `ERR_ERL_PERMISSIVE_TRUST_PROXY`. Trusting
+every hop means any client can spoof its address — and so its rate-limit bucket
+— just by sending its own `X-Forwarded-For` header. Prefer a hop count or an
+explicit trust list.

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -259,6 +259,7 @@ Environment Variables:
   NODERED_PASSWORD    Node-RED password
   JWT_SECRET          JWT secret key
   LOG_LEVEL           Logging level (error/warn/info/debug)
+  TRUST_PROXY         Reverse proxy hops to trust (e.g. 1) or a trust list
 
 Examples:
   docker run -e NODE_ENV=development mcp-nodered-server

--- a/env.example
+++ b/env.example
@@ -49,6 +49,18 @@ LOG_FILE=./logs/mcp-nodered-server.log
 RATE_LIMIT_WINDOW=900000
 RATE_LIMIT_MAX=100
 
+# Reverse proxy support — Express `trust proxy`.
+# Unset/false: X-Forwarded-For is ignored, so every client behind a proxy shares
+# one rate-limit bucket. Set this to the number of proxies in front of this
+# server so req.ip resolves to the real client:
+#   TRUST_PROXY=1                 # one proxy (Traefik, nginx, Caddy, …)
+#   TRUST_PROXY=2                 # e.g. Traefik in front of Pomerium
+#   TRUST_PROXY=loopback          # or a trust list / CIDR, comma-separated
+# `true` works but is not recommended and logs a warning on startup: it trusts
+# every hop, so any client can spoof its address — and its rate-limit bucket —
+# by sending its own X-Forwarded-For header.
+TRUST_PROXY=
+
 # CORS Configuration
 CORS_ORIGIN=*
 CORS_CREDENTIALS=true

--- a/src/server/express-app.test.ts
+++ b/src/server/express-app.test.ts
@@ -105,7 +105,7 @@ vi.mock('../utils/auth.js', () => ({
 }));
 
 // Import after mocks
-import { ExpressApp } from './express-app.js';
+import { ExpressApp, parseTrustProxy } from './express-app.js';
 import type { McpNodeRedServer } from './mcp-server.js';
 
 describe('ExpressApp', () => {
@@ -667,5 +667,116 @@ describe('ExpressApp Configuration', () => {
     const app = expressApp.getApp();
 
     expect(app).toBeDefined();
+  });
+});
+
+describe('parseTrustProxy', () => {
+  it('should not trust proxies when unset or empty', () => {
+    expect(parseTrustProxy(undefined)).toBe(false);
+    expect(parseTrustProxy('')).toBe(false);
+    expect(parseTrustProxy('   ')).toBe(false);
+    expect(parseTrustProxy('false')).toBe(false);
+    expect(parseTrustProxy('FALSE')).toBe(false);
+  });
+
+  it('should read a hop count as a number', () => {
+    expect(parseTrustProxy('1')).toBe(1);
+    expect(parseTrustProxy(' 2 ')).toBe(2);
+    expect(parseTrustProxy('0')).toBe(0);
+  });
+
+  it('should accept true but warn that it allows X-Forwarded-For spoofing', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      expect(parseTrustProxy('true')).toBe(true);
+      expect(parseTrustProxy('True')).toBe(true);
+
+      expect(warn).toHaveBeenCalledTimes(2);
+      const message = warn.mock.calls[0]![0] as string;
+      expect(message).toMatch(/not recommended/i);
+      expect(message).toMatch(/spoof/i);
+      expect(message).toContain('TRUST_PROXY=1');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('should pass a single trust-list entry through as a string', () => {
+    expect(parseTrustProxy('loopback')).toBe('loopback');
+    expect(parseTrustProxy('10.0.0.0/8')).toBe('10.0.0.0/8');
+  });
+
+  it('should split a comma-separated trust list', () => {
+    expect(parseTrustProxy('loopback, 10.0.0.0/8 ,172.16.0.0/12')).toEqual([
+      'loopback',
+      '10.0.0.0/8',
+      '172.16.0.0/12',
+    ]);
+  });
+});
+
+describe('ExpressApp trust proxy', () => {
+  const original = process.env.TRUST_PROXY;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (original === undefined) {
+      delete process.env.TRUST_PROXY;
+    } else {
+      process.env.TRUST_PROXY = original;
+    }
+  });
+
+  it('should leave trust proxy disabled by default', () => {
+    delete process.env.TRUST_PROXY;
+
+    const app = new ExpressApp(mockMcpServer as unknown as McpNodeRedServer).getApp();
+
+    expect(app.get('trust proxy')).toBe(false);
+  });
+
+  it('should apply the hop count from TRUST_PROXY', () => {
+    process.env.TRUST_PROXY = '2';
+
+    const app = new ExpressApp(mockMcpServer as unknown as McpNodeRedServer).getApp();
+
+    expect(app.get('trust proxy')).toBe(2);
+  });
+
+  it('should let an explicit config value win over the environment', () => {
+    process.env.TRUST_PROXY = '2';
+
+    const app = new ExpressApp(mockMcpServer as unknown as McpNodeRedServer, {
+      trustProxy: 'loopback',
+    }).getApp();
+
+    expect(app.get('trust proxy')).toBe('loopback');
+  });
+
+  it('should trust exactly the configured number of hops', () => {
+    process.env.TRUST_PROXY = '1';
+
+    const app = new ExpressApp(mockMcpServer as unknown as McpNodeRedServer).getApp();
+    const trusts = app.get('trust proxy fn') as (addr: string, hop: number) => boolean;
+
+    // Hop 0 is the proxy itself; hop 1 would be a value the client supplied.
+    expect(trusts('10.0.0.1', 0)).toBe(true);
+    expect(trusts('10.0.0.1', 1)).toBe(false);
+  });
+
+  it('should trust no hops when TRUST_PROXY is unset', () => {
+    delete process.env.TRUST_PROXY;
+
+    const app = new ExpressApp(mockMcpServer as unknown as McpNodeRedServer).getApp();
+    const trusts = app.get('trust proxy fn') as (addr: string, hop: number) => boolean;
+
+    expect(trusts('10.0.0.1', 0)).toBe(false);
   });
 });

--- a/src/server/express-app.ts
+++ b/src/server/express-app.ts
@@ -29,6 +29,58 @@ import { OAuthServer } from './oauth-server.js';
 import { SessionManager } from './session-manager.js';
 import { SSEHandler } from './sse-handler.js';
 
+/**
+ * Value accepted by Express's `trust proxy` setting.
+ */
+export type TrustProxySetting = boolean | number | string | string[];
+
+/**
+ * Parse the `TRUST_PROXY` environment variable into an Express `trust proxy`
+ * value.
+ *
+ * Left unset, Express does not trust `X-Forwarded-For`, so every request behind
+ * a reverse proxy is attributed to the proxy's own address: one shared
+ * rate-limit bucket for all clients, and `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR`
+ * from express-rate-limit on the first proxied request.
+ *
+ * Accepted values:
+ *   - a number    — hop count, e.g. `1` for a single proxy in front (recommended)
+ *   - `false`     — no proxy; use the socket address (the default)
+ *   - `true`      — trust every hop. Accepted, but warned about on startup: it
+ *                   lets a client spoof its address by sending its own
+ *                   `X-Forwarded-For`, and express-rate-limit reports it as
+ *                   ERR_ERL_PERMISSIVE_TRUST_PROXY
+ *   - anything else — passed through to Express as a trust list, e.g.
+ *                   `loopback`, `10.0.0.0/8`, or a comma-separated combination
+ */
+export function parseTrustProxy(raw: string | undefined): TrustProxySetting {
+  const value = raw?.trim();
+  if (!value) return false;
+
+  const normalized = value.toLowerCase();
+  if (normalized === 'false') return false;
+  if (normalized === 'true') {
+    console.warn(
+      'TRUST_PROXY=true is not recommended: it trusts every hop, so any client can spoof its ' +
+        'address — and its rate-limit bucket — by sending its own X-Forwarded-For header. ' +
+        'Set the number of proxies in front of this server instead (e.g. TRUST_PROXY=1), ' +
+        'or list the trusted addresses (e.g. TRUST_PROXY=loopback,10.0.0.0/8).'
+    );
+    return true;
+  }
+
+  if (/^\d+$/.test(value)) {
+    return Number(value);
+  }
+
+  const entries = value
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(Boolean);
+
+  return entries.length > 1 ? entries : entries[0]!;
+}
+
 export interface ExpressAppConfig {
   port: number;
   host: string;
@@ -41,6 +93,11 @@ export interface ExpressAppConfig {
     max: number;
   };
   helmet: boolean;
+  /**
+   * Express `trust proxy` setting. Defaults to `TRUST_PROXY`, or `false` when
+   * that is unset.
+   */
+  trustProxy: TrustProxySetting;
 }
 
 export class ExpressApp {
@@ -75,10 +132,13 @@ export class ExpressApp {
         max: parseInt(process.env.RATE_LIMIT_MAX_REQUESTS || '100'),
       },
       helmet: process.env.DISABLE_HELMET !== 'true',
+      trustProxy: parseTrustProxy(process.env.TRUST_PROXY),
       ...config,
     };
 
     this.app = express();
+    // Must be set before the rate limiters read req.ip.
+    this.app.set('trust proxy', this.config.trustProxy);
     this.setupMiddleware();
     this.setupRoutes();
     this.setupErrorHandling();

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -31,6 +31,9 @@ export const envSchema = z.object({
   CORS_ORIGIN: z.string().default('*'),
   RATE_LIMIT_WINDOW: z.coerce.number().int().positive().default(900000), // 15 minutes
   RATE_LIMIT_MAX: z.coerce.number().int().positive().default(100),
+  // Express `trust proxy`: hop count (e.g. "1"), "false", or a trust list such
+  // as "loopback" or "10.0.0.0/8". Parsed by parseTrustProxy() in express-app.
+  TRUST_PROXY: z.string().optional(),
 
   // Logging Configuration
   LOG_LEVEL: z.enum(['error', 'warn', 'info', 'debug']).default('info'),

--- a/src/utils/auth.test.ts
+++ b/src/utils/auth.test.ts
@@ -682,5 +682,39 @@ describe('Rate Limiting Utilities', () => {
 
       expect(key).toBe('ip:unknown');
     });
+
+    it('should collapse an IPv6 address to its subnet prefix', () => {
+      const { req } = createMockReqRes();
+      (req as any).ip = '2001:db8:1234:5678:9abc:def0:1234:5678';
+
+      const key = getRateLimitKey(req as any);
+
+      expect(key).not.toBe('ip:2001:db8:1234:5678:9abc:def0:1234:5678');
+      expect(key).toMatch(/^ip:.+\/\d+$/);
+    });
+
+    it('should give two addresses in the same IPv6 subnet the same key', () => {
+      const { req: first } = createMockReqRes();
+      const { req: second } = createMockReqRes();
+      (first as any).ip = '2001:db8:1234:5600::1';
+      (second as any).ip = '2001:db8:1234:5600::dead:beef';
+
+      expect(getRateLimitKey(first as any)).toBe(getRateLimitKey(second as any));
+    });
+
+    it('should leave IPv4 addresses untouched', () => {
+      const { req } = createMockReqRes();
+      (req as any).ip = '203.0.113.7';
+
+      expect(getRateLimitKey(req as any)).toBe('ip:203.0.113.7');
+    });
+
+    it('should still prefer the user key for an authenticated IPv6 client', () => {
+      const { req } = createMockReqRes();
+      (req as any).ip = '2001:db8::1';
+      req.auth = { userId: 'user123', permissions: [], isAuthenticated: true };
+
+      expect(getRateLimitKey(req as any)).toBe('user:user123');
+    });
   });
 });

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -5,6 +5,7 @@
 import { timingSafeEqual } from 'crypto';
 
 import { Request, Response, NextFunction } from 'express';
+import { ipKeyGenerator } from 'express-rate-limit';
 import jwt from 'jsonwebtoken';
 
 import { McpAuthContext, NodeRedToolPermissions } from '../types/mcp-extensions.js';
@@ -340,7 +341,17 @@ export function getNodeRedAuthHeader(): Record<string, string> {
 }
 
 /**
- * Rate limiting by user ID or IP
+ * Rate limiting by user ID or IP.
+ *
+ * The IP fallback runs through express-rate-limit's `ipKeyGenerator`, which
+ * collapses an IPv6 address to its subnet prefix. Keying on the raw address let
+ * an IPv6 client rotate through its allocation — typically a /64 or larger — for
+ * a fresh bucket per request, and made express-rate-limit emit
+ * `ERR_ERL_KEY_GEN_IPV6` at startup. IPv4 addresses pass through unchanged.
+ *
+ * No subnet is passed so this matches the default the library applies to the
+ * limiters that don't override `keyGenerator`, keeping every limiter's IPv6
+ * grouping identical.
  */
 export function getRateLimitKey(req: Request): string {
   const authReq = req as AuthRequest;
@@ -348,5 +359,6 @@ export function getRateLimitKey(req: Request): string {
     return `user:${authReq.auth.userId}`;
   }
 
-  return `ip:${req.ip || req.connection.remoteAddress || 'unknown'}`;
+  const ip = req.ip || req.socket?.remoteAddress || req.connection?.remoteAddress;
+  return `ip:${ip ? ipKeyGenerator(ip) : 'unknown'}`;
 }


### PR DESCRIPTION
Addresses ziv-daniel/node-red-mcp#106.

1. ERR_ERL_KEY_GEN_IPV6 — getRateLimitKey keyed on the raw address

   The custom keyGenerator returned `ip:${req.ip}` verbatim. For IPv6 that gives a client its own bucket for every address in its allocation — typically a /64 or larger — so the limit is trivially bypassed by rotating source addresses, and express-rate-limit flagged it at startup.

   The IP fallback now runs through express-rate-limit's ipKeyGenerator, which collapses IPv6 to its subnet prefix and leaves IPv4 untouched. No explicit subnet is passed so the grouping matches what the library already applies to the limiters that don't override keyGenerator (/mcp, /sse, /messages, /oauth), keeping every limiter consistent.

   The socket fallback is also optional-chained; it previously read req.connection.remoteAddress unguarded.

2. ERR_ERL_UNEXPECTED_X_FORWARDED_FOR — trust proxy was never set

   Express defaults to not trusting X-Forwarded-For, so behind a reverse proxy every request resolves to the proxy's own address: all clients share one bucket (60 req/min collectively on the MCP endpoints), and express-rate-limit warns on the first proxied request.

   `trust proxy` is now configurable via TRUST_PROXY and applied before the limiters read req.ip. It takes a hop count (TRUST_PROXY=1 for a single proxy, 2 for e.g. Traefik in front of Pomerium), `false`, or a trust list such as `loopback` or a comma-separated set of CIDRs. It defaults to false, so direct deployments are unchanged.

   `true` is accepted but logs a startup warning: it trusts every hop, so any client can spoof its address — and its rate-limit bucket — by sending its own X-Forwarded-For header, and express-rate-limit reports it as ERR_ERL_PERMISSIVE_TRUST_PROXY. The setting is also exposed on ExpressAppConfig so an embedder can pass it directly.

Documented in env.example, the container entrypoint help text, the env schema, and a new "Running Behind a Reverse Proxy" section in the README listing every accepted value.


Claude-Session: https://claude.ai/code/session_01318azTDgNDQa7j6Q5Wy7o2